### PR TITLE
feat: HIG-compliant preferences, templates, focus/typewriter mode and zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+### Added — interfaz HIG, plantillas y preferencias
+
+- **Preferencias completas** (`src/preferences.rs`) con `AdwPreferencesWindow` y
+  tres paginas: Apariencia (esquema de color, familia tipografica, tamano,
+  interlineado, ancho de columna), Editor (visibilidad del marcado, continuar
+  listas, modo foco, maquina de escribir, tabulacion, autoguardado e intervalo)
+  y Plantillas.
+- **Plantillas** (`src/templates.rs`): ficheros `.md` en
+  `$XDG_DATA_HOME/scribe/templates`, sembrados con cuatro ejemplos la primera
+  vez. Admiten `{{title}}`, `{{date}}`, `{{time}}`, `{{datetime}}` y `{{year}}`.
+- **Visibilidad del marcado configurable**: ocultar siempre, revelar en la linea
+  del cursor o atenuar siempre.
+- **Modo foco** (Ctrl+Shift+F) y **maquina de escribir** (Ctrl+Shift+T).
+- **Continuacion de listas** al pulsar Intro, con renumeracion de las ordenadas
+  y cierre automatico al dejar un elemento vacio.
+- **Zoom** (Ctrl +/-/0) con fila de control en el menu principal.
+- **Ir a la linea** desde la barra de estado.
+- **Marcado ampliado**: cabeceras setext, autoenlaces `<url>`, notas al pie,
+  bloques HTML atenuados y tablas en monoespaciada para que las columnas cuadren.
+  Tests: 13 -> 16.
+- **Ventana de atajos** externalizada a `src/shortcuts.ui`.
+
+### Changed
+
+- **Cabecera reorganizada** igual que GNOME Text Editor: `AdwSplitButton`
+  «Abrir» con desplegable de recientes y boton de documento nuevo a la
+  izquierda, titulo al centro, menu principal a la derecha. La barra de estado
+  lleva el contador de palabras a la izquierda y los botones de posicion y
+  propiedades a la derecha.
+- **Alternancias con estado** (`SimpleAction::new_stateful`) para barra lateral,
+  vista dividida, modo foco y maquina de escribir: el menu muestra la marca.
+- **Esquema GSettings** reescrito con enumeraciones y rangos.
+- **`settings.rs`** reescrito con tipos propios (`MarkupVisibility`,
+  `FontFamily`) en lugar de cadenas sueltas.
+
+### Fixed
+
+- Restauradas `app.quit` y `app.new-window`, que se habian perdido al rehacer
+  `main.rs`: Ctrl+Q no hacia nada y dos entradas del menu salian grises.
+- Restaurado `ApplicationFlags::HANDLES_OPEN`, sin el cual `scribe fichero.md` y
+  «Abrir con» del gestor de archivos se ignoraban.
+- `GtkTextTag:letter-spacing` no admite valores negativos: usarlos abortaba la
+  aplicacion al construir los tags de cabecera.
+
+### Added — render WYSIWYG en linea
 
 - **Inline WYSIWYG rendering**: the editor buffer is now decorated with `GtkTextTag`
   spans computed from the Markdown source. Headings render at their actual scale,

--- a/README.md
+++ b/README.md
@@ -13,23 +13,30 @@ sigue las GNOME Human Interface Guidelines.
 
 ## Que hace ahora mismo
 
-- **Render en vivo (WYSIWYG en linea)**: se decora el buffer del editor con
-  `GtkTextTag`. Las marcas de Markdown llevan la propiedad `invisible` y se revelan
-  atenuadas en la linea del cursor. Cubre cabeceras, negrita, cursiva, tachado,
-  codigo en linea y en bloque, citas, listas con sangria colgante, listas anidadas,
-  tareas, enlaces y reglas.
-- **Tipografia**: columna centrada de 720 px, cuerpo en Cantarell, monoespaciada solo
-  para codigo. Tema claro y oscuro con el *style scheme* de GtkSourceView.
-- **Previsualizacion dividida** (opcional, Ctrl+Shift+P): render completo en un panel
-  aparte, util para tablas. Desactivada por defecto.
-- **Ficheros**: abrir, guardar y guardar como con `GtkFileDialog`. Escritura atomica
-  (temporal + rename). Aviso al cerrar si hay cambios sin guardar.
-- **Integracion**: `scribe fichero.md` y "Abrir con" del gestor de archivos funcionan.
-- **Barra lateral**: recientes reales (persistidos en GSettings) con filtro, e indice
-  del documento navegable.
-- **Preferencias**: tamano de fuente, interlineado y autoguardado, persistidos en GSettings.
-- **Formato**: Ctrl+B, Ctrl+I y Ctrl+K envuelven la seleccion.
-- **Barra de estado** al estilo de GNOME Text Editor: palabras, caracteres y Ln/Col.
+- **Render en vivo (WYSIWYG en linea)**: el buffer del editor se decora con
+  `GtkTextTag`. Las marcas de Markdown llevan la propiedad `invisible` y su
+  visibilidad es configurable: ocultas siempre, reveladas en la linea del cursor,
+  o atenuadas siempre. Cubre cabeceras ATX y setext, negrita, cursiva, tachado,
+  codigo en linea y en bloque, citas, listas con sangria colgante, listas
+  anidadas, tareas, enlaces, autoenlaces, notas al pie, tablas, HTML y reglas.
+- **Tipografia**: columna centrada de ancho configurable, familia sans/serif/mono
+  a elegir y monoespaciada reservada para codigo y tablas. Tema claro y oscuro
+  con el style scheme de GtkSourceView.
+- **Modo foco y maquina de escribir**: atenuar todo salvo el parrafo actual y
+  mantener la linea del cursor centrada verticalmente.
+- **Plantillas**: ficheros `.md` en `~/.local/share/scribe/templates`, con
+  marcadores `{{title}}`, `{{date}}`, `{{time}}`, `{{datetime}}` y `{{year}}`.
+  Se eligen desde el boton de documento nuevo o se fija una por defecto.
+- **Interfaz segun las HIG**, con el mismo reparto que GNOME Text Editor: boton
+  «Abrir» con desplegable de recientes y boton de documento nuevo a la izquierda,
+  titulo al centro, menu principal con fila de zoom a la derecha, y barra de
+  estado inferior con posicion del cursor e «Ir a la linea».
+- **Preferencias** en tres paginas: apariencia, editor y plantillas.
+- **Ficheros**: abrir, guardar y guardar como con `GtkFileDialog`, escritura
+  atomica, aviso de cambios sin guardar y autoguardado con intervalo ajustable.
+- **Integracion**: `scribe fichero.md` y «Abrir con» del gestor de archivos.
+- **Barra lateral** (F9) con recientes filtrables e indice del documento navegable.
+- **Previsualizacion dividida** (opcional, Ctrl+Shift+P) para tablas e imagenes.
 
 ## Limites conocidos del render en vivo
 
@@ -47,9 +54,10 @@ anclas en el buffer, que altera el texto fuente. Queda fuera de esta fase.
 
 ## Que falta
 
-- Modo foco y modo maquina de escribir.
+- Pestanas / varios documentos por ventana (`AdwTabView`).
+- Buscar y reemplazar.
 - Exportar a HTML o PDF.
-- Tabla de estilos configurable.
+- Correccion ortografica.
 
 ## Requisitos de compilacion
 

--- a/data/app.scribe.Scribe.gschema.xml
+++ b/data/app.scribe.Scribe.gschema.xml
@@ -1,5 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
+  <enum id="app.scribe.Scribe.MarkupVisibility">
+    <value nick="hidden" value="0"/>
+    <value nick="focus" value="1"/>
+    <value nick="dim" value="2"/>
+  </enum>
+  <enum id="app.scribe.Scribe.ColorScheme">
+    <value nick="system" value="0"/>
+    <value nick="light" value="1"/>
+    <value nick="dark" value="2"/>
+  </enum>
+  <enum id="app.scribe.Scribe.FontFamily">
+    <value nick="sans" value="0"/>
+    <value nick="serif" value="1"/>
+    <value nick="mono" value="2"/>
+  </enum>
+
   <schema id="app.scribe.Scribe" path="/app/scribe/Scribe/">
     <key name="window-width" type="i">
       <default>1100</default>
@@ -9,29 +25,79 @@
       <default>800</default>
       <summary>Window height</summary>
     </key>
+    <key name="window-maximized" type="b">
+      <default>false</default>
+      <summary>Window is maximized</summary>
+    </key>
+
     <key name="show-sidebar" type="b">
       <default>false</default>
       <summary>Show sidebar</summary>
     </key>
     <key name="show-preview" type="b">
       <default>false</default>
-      <summary>Show preview panel</summary>
+      <summary>Show split preview</summary>
     </key>
-    <key name="theme" type="s">
-      <default>"system"</default>
-      <summary>Color theme</summary>
+
+    <key name="color-scheme" enum="app.scribe.Scribe.ColorScheme">
+      <default>'system'</default>
+      <summary>Color scheme</summary>
+    </key>
+    <key name="font-family" enum="app.scribe.Scribe.FontFamily">
+      <default>'sans'</default>
+      <summary>Editor font family</summary>
     </key>
     <key name="font-size" type="i">
       <default>16</default>
+      <range min="9" max="40"/>
       <summary>Editor font size</summary>
     </key>
     <key name="line-spacing" type="d">
       <default>1.7</default>
+      <range min="1.0" max="3.0"/>
       <summary>Line spacing</summary>
     </key>
+    <key name="column-width" type="i">
+      <default>720</default>
+      <range min="480" max="1400"/>
+      <summary>Maximum text column width in pixels</summary>
+    </key>
+
+    <key name="markup-visibility" enum="app.scribe.Scribe.MarkupVisibility">
+      <default>'focus'</default>
+      <summary>When to show Markdown syntax markers</summary>
+    </key>
+    <key name="focus-mode" type="b">
+      <default>false</default>
+      <summary>Dim everything except the current paragraph</summary>
+    </key>
+    <key name="typewriter-mode" type="b">
+      <default>false</default>
+      <summary>Keep the cursor line vertically centred</summary>
+    </key>
+    <key name="continue-lists" type="b">
+      <default>true</default>
+      <summary>Continue lists when pressing Enter</summary>
+    </key>
+    <key name="tab-width" type="i">
+      <default>4</default>
+      <range min="2" max="8"/>
+      <summary>Tab width</summary>
+    </key>
+
     <key name="autosave" type="b">
       <default>true</default>
       <summary>Autosave</summary>
+    </key>
+    <key name="autosave-interval" type="i">
+      <default>30</default>
+      <range min="5" max="600"/>
+      <summary>Autosave interval in seconds</summary>
+    </key>
+
+    <key name="default-template" type="s">
+      <default>''</default>
+      <summary>Template used for new documents (empty means blank)</summary>
     </key>
     <key name="recent-files" type="as">
       <default>[]</default>

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -7,25 +7,38 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use crate::markdown_render::{spans, MAX_LIVE_BYTES};
+use crate::settings::{FontFamily, MarkupVisibility};
 
 type ChangedCallback = Rc<RefCell<Option<Box<dyn Fn(&str)>>>>;
 
-/// Ancho máximo de la columna de texto, al estilo Typora.
-const COLUMN_WIDTH: i32 = 720;
 const MIN_MARGIN: i32 = 24;
 
-/// Sangría extra (en px) de cada tag de bloque respecto al margen de la columna.
-const BLOCK_INDENTS: [(&str, i32); 5] = [
-    ("quote", 24),
-    ("codeblock", 20),
+/// Sangría extra (px) de cada tag de bloque respecto al margen de la columna.
+const BLOCK_INDENTS: [(&str, i32); 6] = [
+    ("quote", 26),
+    ("codeblock", 22),
+    ("table", 22),
     ("li1", 26),
     ("li2", 52),
     ("li3", 78),
 ];
 
+#[derive(Clone, Copy)]
+struct Decoration {
+    markup: MarkupVisibility,
+    focus_mode: bool,
+}
+
+impl Default for Decoration {
+    fn default() -> Self {
+        Self {
+            markup: MarkupVisibility::Focus,
+            focus_mode: false,
+        }
+    }
+}
+
 pub struct Editor {
-    /// El `ScrolledWindow` es el widget que se mete en la ventana.
-    /// Sin él el documento no se podía desplazar.
     pub widget: gtk4::ScrolledWindow,
     pub view: gtksourceview5::View,
     buffer: gtksourceview5::Buffer,
@@ -34,6 +47,10 @@ pub struct Editor {
     css: gtk4::CssProvider,
     last_line: Rc<Cell<i32>>,
     generation: Rc<Cell<u64>>,
+    decoration: Rc<Cell<Decoration>>,
+    column_width: Rc<Cell<i32>>,
+    continue_lists: Rc<Cell<bool>>,
+    typewriter: Rc<Cell<bool>>,
 }
 
 fn build_tags() -> gtk4::TextTagTable {
@@ -42,38 +59,51 @@ fn build_tags() -> gtk4::TextTagTable {
         table.add(&t);
     };
 
-    // El orden importa: en GTK, el tag añadido más tarde tiene más prioridad.
-    // Bloques primero, luego cabeceras, luego elementos en línea y al final
-    // las marcas de sintaxis, que deben ganar siempre.
+    // El orden fija la prioridad: lo añadido después gana.
+    // Bloques → cabeceras → en línea → marcas de sintaxis → atenuado de foco.
 
     for (name, indent) in BLOCK_INDENTS {
         let builder = gtk4::TextTag::builder().name(name);
         let tag = match name {
             "quote" => builder.style(pango::Style::Italic).build(),
-            "codeblock" => builder.family("monospace").scale(0.92).build(),
+            "codeblock" | "table" => builder.family("monospace").scale(0.9).build(),
             _ => builder.indent(-indent).build(),
         };
         add(tag);
     }
 
     add(gtk4::TextTag::builder()
+        .name("tabledelim")
+        .family("monospace")
+        .scale(0.9)
+        .build());
+    add(gtk4::TextTag::builder()
         .name("fence")
         .family("monospace")
-        .scale(0.75)
+        .scale(0.7)
         .build());
     add(gtk4::TextTag::builder()
         .name("rule")
-        .scale(0.8)
+        .scale(0.7)
         .justification(gtk4::Justification::Center)
+        .pixels_above_lines(14)
+        .pixels_below_lines(14)
+        .build());
+    add(gtk4::TextTag::builder()
+        .name("html")
+        .family("monospace")
+        .scale(0.85)
         .build());
 
+    // Nota: GtkTextTag:letter-spacing no admite valores negativos, así que el
+    // ajuste óptico de las cabeceras se hace solo con escala y peso.
     for (name, scale, weight, above, below) in [
-        ("h1", 1.85_f64, 800, 26, 10),
-        ("h2", 1.45, 700, 22, 8),
-        ("h3", 1.2, 700, 18, 6),
-        ("h4", 1.05, 700, 14, 4),
-        ("h5", 1.0, 700, 12, 4),
-        ("h6", 1.0, 700, 12, 4),
+        ("h1", 1.9_f64, 800, 30, 12),
+        ("h2", 1.5, 750, 26, 10),
+        ("h3", 1.24, 700, 20, 8),
+        ("h4", 1.1, 700, 16, 6),
+        ("h5", 1.0, 700, 14, 5),
+        ("h6", 1.0, 700, 14, 5),
     ] {
         add(gtk4::TextTag::builder()
             .name(name)
@@ -96,11 +126,16 @@ fn build_tags() -> gtk4::TextTagTable {
     add(gtk4::TextTag::builder()
         .name("code")
         .family("monospace")
-        .scale(0.92)
+        .scale(0.9)
         .build());
     add(gtk4::TextTag::builder()
         .name("link")
         .underline(pango::Underline::Single)
+        .build());
+    add(gtk4::TextTag::builder()
+        .name("footnote")
+        .scale(0.8)
+        .rise(4000)
         .build());
     add(gtk4::TextTag::builder()
         .name("listmarker")
@@ -112,18 +147,20 @@ fn build_tags() -> gtk4::TextTagTable {
         .weight(700)
         .build());
 
-    // Marcas de Markdown: ocultas por defecto, atenuadas en la línea del cursor.
     add(gtk4::TextTag::builder()
         .name("syn_hidden")
         .invisible(true)
         .build());
     add(gtk4::TextTag::builder().name("syn_shown").build());
 
+    // El modo foco atenúa todo lo que no sea el párrafo actual, así que va
+    // el último para pisar el color de cualquier otro tag.
+    add(gtk4::TextTag::builder().name("unfocused").build());
+
     table
 }
 
-/// GtkSourceView pinta el fondo del buffer desde su *style scheme*, no desde el
-/// tema GTK: sin esto la ventana se pone oscura pero el texto se queda en claro.
+/// GtkSourceView pinta el fondo desde su *style scheme*, no desde el tema GTK.
 fn apply_scheme(buffer: &gtksourceview5::Buffer, dark: bool) {
     let manager = gtksourceview5::StyleSchemeManager::default();
     let candidates: [&str; 2] = if dark {
@@ -150,28 +187,36 @@ fn apply_theme(tags: &gtk4::TextTagTable, dark: bool) {
     if dark {
         set("code", Some("#f0a868"), None);
         set("codeblock", Some("#e0e0e0"), Some("#343434"));
+        set("table", Some("#e0e0e0"), Some("#2c2c2c"));
+        set("tabledelim", Some("#7c7c7c"), Some("#2c2c2c"));
         set("fence", Some("#7c7c7c"), Some("#343434"));
         set("quote", Some("#c2c2c2"), Some("#2e2e2e"));
         set("link", Some("#82b8f0"), None);
+        set("footnote", Some("#82b8f0"), None);
         set("listmarker", Some("#82b8f0"), None);
         set("task", Some("#82b8f0"), None);
         set("rule", Some("#6f6f6f"), None);
-        set("syn_shown", Some("#7a7a7a"), None);
+        set("html", Some("#8f8f8f"), None);
+        set("syn_shown", Some("#787878"), None);
+        set("unfocused", Some("#5c5c5c"), None);
     } else {
         set("code", Some("#a34a00"), None);
         set("codeblock", Some("#1f1f1f"), Some("#f4f3f2"));
+        set("table", Some("#1f1f1f"), Some("#f7f6f5"));
+        set("tabledelim", Some("#a9a8a5"), Some("#f7f6f5"));
         set("fence", Some("#9a9996"), Some("#f4f3f2"));
         set("quote", Some("#54535a"), Some("#f6f5f4"));
         set("link", Some("#1a6ed8"), None);
+        set("footnote", Some("#1a6ed8"), None);
         set("listmarker", Some("#1a6ed8"), None);
         set("task", Some("#1a6ed8"), None);
         set("rule", Some("#9a9996"), None);
-        set("syn_shown", Some("#a9a8a5"), None);
+        set("html", Some("#8b8a88"), None);
+        set("syn_shown", Some("#b5b4b1"), None);
+        set("unfocused", Some("#bdbcba"), None);
     }
 }
 
-/// Los tags de bloque llevan margen absoluto, así que hay que recalcularlos
-/// cada vez que cambia el ancho de la columna centrada.
 fn set_column_margins(tags: &gtk4::TextTagTable, base: i32) {
     for (name, extra) in BLOCK_INDENTS {
         if let Some(tag) = tags.lookup(name) {
@@ -179,17 +224,41 @@ fn set_column_margins(tags: &gtk4::TextTagTable, base: i32) {
             tag.set_right_margin(base);
         }
     }
-    for name in ["fence", "rule"] {
+    for name in ["fence", "rule", "tabledelim"] {
         if let Some(tag) = tags.lookup(name) {
-            tag.set_left_margin(base + 20);
+            tag.set_left_margin(base + 22);
             tag.set_right_margin(base);
         }
     }
 }
 
-/// Vuelve a decorar todo el buffer. Se llama con debounce al escribir y
-/// al cambiar el cursor de línea.
-fn decorate(buffer: &gtksourceview5::Buffer) {
+/// Límites del párrafo (bloque separado por líneas en blanco) que contiene `line`.
+fn paragraph_bounds(buffer: &gtksourceview5::Buffer, line: i32) -> (i32, i32) {
+    let is_blank = |n: i32| -> bool {
+        match buffer.iter_at_line(n) {
+            Some(start) => {
+                let mut end = start;
+                if !end.ends_line() {
+                    end.forward_to_line_end();
+                }
+                buffer.text(&start, &end, true).trim().is_empty()
+            }
+            None => true,
+        }
+    };
+    let mut first = line;
+    while first > 0 && !is_blank(first - 1) {
+        first -= 1;
+    }
+    let last_line = buffer.end_iter().line();
+    let mut last = line;
+    while last < last_line && !is_blank(last + 1) {
+        last += 1;
+    }
+    (first, last)
+}
+
+fn decorate(buffer: &gtksourceview5::Buffer, config: Decoration) {
     let start = buffer.start_iter();
     let end = buffer.end_iter();
     buffer.remove_all_tags(&start, &end);
@@ -222,24 +291,89 @@ fn decorate(buffer: &gtksourceview5::Buffer) {
         let start_iter = buffer.iter_at_offset(from);
         let end_iter = buffer.iter_at_offset(to);
         let name = if span.syntax {
-            if start_iter.line() <= cursor_line && end_iter.line() >= cursor_line {
-                "syn_shown"
-            } else {
-                "syn_hidden"
+            match config.markup {
+                MarkupVisibility::Hidden => "syn_hidden",
+                MarkupVisibility::Dim => "syn_shown",
+                MarkupVisibility::Focus => {
+                    if start_iter.line() <= cursor_line && end_iter.line() >= cursor_line {
+                        "syn_shown"
+                    } else {
+                        "syn_hidden"
+                    }
+                }
             }
         } else {
             span.tag
         };
         buffer.apply_tag_by_name(name, &start_iter, &end_iter);
     }
+
+    if config.focus_mode {
+        let (first, last) = paragraph_bounds(buffer, cursor_line);
+        if let Some(para_start) = buffer.iter_at_line(first) {
+            buffer.apply_tag_by_name("unfocused", &buffer.start_iter(), &para_start);
+        }
+        let after = buffer
+            .iter_at_line(last + 1)
+            .unwrap_or_else(|| buffer.end_iter());
+        buffer.apply_tag_by_name("unfocused", &after, &buffer.end_iter());
+    }
+}
+
+/// Marcador que continúa una lista, o `None` si la línea no es un elemento.
+/// El `bool` indica que el elemento está vacío, en cuyo caso hay que cerrarlo.
+fn list_continuation(line: &str) -> Option<(String, bool)> {
+    let indent: String = line
+        .chars()
+        .take_while(|c| *c == ' ' || *c == '\t')
+        .collect();
+    let rest = &line[indent.len()..];
+    let mut chars = rest.chars();
+    let first = chars.next()?;
+
+    let (marker, body) = if matches!(first, '-' | '*' | '+') {
+        let after = &rest[1..];
+        let gap = after.len() - after.trim_start_matches(' ').len();
+        if gap == 0 {
+            return None;
+        }
+        (format!("{first}{}", " ".repeat(gap)), &after[gap..])
+    } else if first.is_ascii_digit() {
+        let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+        let after = &rest[digits.len()..];
+        let delim = after.chars().next()?;
+        if delim != '.' && delim != ')' {
+            return None;
+        }
+        let after = &after[1..];
+        let gap = after.len() - after.trim_start_matches(' ').len();
+        if gap == 0 {
+            return None;
+        }
+        let next = digits.parse::<u64>().unwrap_or(1) + 1;
+        (format!("{next}{delim}{}", " ".repeat(gap)), &after[gap..])
+    } else {
+        return None;
+    };
+
+    // Casillas de tarea: la siguiente empieza sin marcar.
+    let (marker, body) = if let Some(stripped) = body
+        .strip_prefix("[ ] ")
+        .or_else(|| body.strip_prefix("[x] "))
+        .or_else(|| body.strip_prefix("[X] "))
+    {
+        (format!("{marker}[ ] "), stripped)
+    } else {
+        (marker, body)
+    };
+
+    Some((format!("{indent}{marker}"), body.trim().is_empty()))
 }
 
 impl Editor {
     pub fn new() -> Self {
         let tags = build_tags();
         let buffer = gtksourceview5::Buffer::new(Some(&tags));
-        // La decoración la ponemos nosotros; el resaltado de GtkSourceView
-        // pintaría por encima y duplicaría el trabajo.
         buffer.set_highlight_syntax(false);
         buffer.set_highlight_matching_brackets(false);
 
@@ -253,8 +387,8 @@ impl Editor {
             .tab_width(4)
             .insert_spaces_instead_of_tabs(true)
             .smart_backspace(true)
-            .top_margin(48)
-            .bottom_margin(240)
+            .top_margin(52)
+            .bottom_margin(280)
             .left_margin(MIN_MARGIN)
             .right_margin(MIN_MARGIN)
             .build();
@@ -290,22 +424,26 @@ impl Editor {
             css,
             last_line: Rc::new(Cell::new(-1)),
             generation: Rc::new(Cell::new(0)),
+            decoration: Rc::new(Cell::new(Decoration::default())),
+            column_width: Rc::new(Cell::new(720)),
+            continue_lists: Rc::new(Cell::new(true)),
+            typewriter: Rc::new(Cell::new(false)),
         };
         editor.connect_signals();
         editor
     }
 
     fn connect_signals(&self) {
-        // Columna centrada: se recalcula con el ancho real de la vista.
         if let Some(hadj) = self.view.hadjustment() {
             let view = self.view.clone();
             let tags = self.tags.clone();
+            let column_width = self.column_width.clone();
             hadj.connect_page_size_notify(move |adj| {
                 let width = adj.page_size() as i32;
                 if width <= 0 {
                     return;
                 }
-                let margin = ((width - COLUMN_WIDTH) / 2).max(MIN_MARGIN);
+                let margin = ((width - column_width.get()) / 2).max(MIN_MARGIN);
                 if view.left_margin() != margin {
                     view.set_left_margin(margin);
                     view.set_right_margin(margin);
@@ -314,19 +452,19 @@ impl Editor {
             });
         }
 
-        // Tema claro/oscuro: los colores de un GtkTextTag son fijos.
         let tags = self.tags.clone();
         let buffer = self.buffer.clone();
+        let decoration = self.decoration.clone();
         adw::StyleManager::default().connect_dark_notify(move |sm| {
             apply_scheme(&buffer, sm.is_dark());
             apply_theme(&tags, sm.is_dark());
-            decorate(&buffer);
+            decorate(&buffer, decoration.get());
         });
 
-        // Al escribir: avisar y redecorar con debounce.
         let on_changed = self.on_changed.clone();
         let generation = self.generation.clone();
         let last_line = self.last_line.clone();
+        let decoration = self.decoration.clone();
         self.buffer.connect_changed(move |buf| {
             let text = buf.text(&buf.start_iter(), &buf.end_iter(), true);
             if let Some(cb) = on_changed.borrow().as_ref() {
@@ -337,27 +475,90 @@ impl Editor {
             generation.set(current);
             let generation = generation.clone();
             let last_line = last_line.clone();
+            let decoration = decoration.clone();
             let buf = buf.clone();
             glib::timeout_add_local_once(Duration::from_millis(45), move || {
                 if generation.get() != current {
                     return;
                 }
                 last_line.set(buf.iter_at_offset(buf.cursor_position()).line());
-                decorate(&buf);
+                decorate(&buf, decoration.get());
             });
         });
 
-        // Al mover el cursor de línea: revelar u ocultar las marcas.
         let last_line = self.last_line.clone();
+        let decoration = self.decoration.clone();
+        let typewriter = self.typewriter.clone();
+        let view = self.view.clone();
         self.buffer.connect_cursor_position_notify(move |buf| {
+            if typewriter.get() {
+                let view = view.clone();
+                let mark = buf.get_insert();
+                glib::idle_add_local_once(move || {
+                    view.scroll_to_mark(&mark, 0.0, true, 0.0, 0.5);
+                });
+            }
             let line = buf.iter_at_offset(buf.cursor_position()).line();
             if last_line.get() == line {
                 return;
             }
             last_line.set(line);
-            decorate(buf);
+            // En modo "siempre ocultas" o "siempre atenuadas" el marcado no
+            // depende del cursor; solo hay que repintar si algo lo sigue.
+            let config = decoration.get();
+            if config.markup == MarkupVisibility::Focus || config.focus_mode {
+                decorate(buf, config);
+            }
         });
+
+        // Continuar listas al pulsar Intro. Fase de captura para adelantarnos
+        // al manejador propio del GtkTextView.
+        let controller = gtk4::EventControllerKey::new();
+        controller.set_propagation_phase(gtk4::PropagationPhase::Capture);
+        let buffer = self.buffer.clone();
+        let continue_lists = self.continue_lists.clone();
+        controller.connect_key_pressed(move |_, key, _, state| {
+            let plain = !state.intersects(
+                gdk4::ModifierType::CONTROL_MASK
+                    | gdk4::ModifierType::SHIFT_MASK
+                    | gdk4::ModifierType::ALT_MASK,
+            );
+            if !continue_lists.get()
+                || !plain
+                || !matches!(key, gdk4::Key::Return | gdk4::Key::KP_Enter)
+            {
+                return glib::Propagation::Proceed;
+            }
+
+            let cursor = buffer.iter_at_offset(buffer.cursor_position());
+            if !cursor.ends_line() || buffer.selection_bounds().is_some() {
+                return glib::Propagation::Proceed;
+            }
+            let Some(line_start) = buffer.iter_at_line(cursor.line()) else {
+                return glib::Propagation::Proceed;
+            };
+            let line = buffer.text(&line_start, &cursor, true).to_string();
+            let Some((marker, empty)) = list_continuation(&line) else {
+                return glib::Propagation::Proceed;
+            };
+
+            buffer.begin_user_action();
+            if empty {
+                // Elemento vacío: se cierra la lista en vez de seguirla.
+                let mut from = line_start;
+                let mut to = cursor;
+                buffer.delete(&mut from, &mut to);
+            } else {
+                let mut at = buffer.iter_at_offset(buffer.cursor_position());
+                buffer.insert(&mut at, &format!("\n{marker}"));
+            }
+            buffer.end_user_action();
+            glib::Propagation::Stop
+        });
+        self.view.add_controller(controller);
     }
+
+    // --- contenido -------------------------------------------------------
 
     pub fn set_text(&self, text: &str) {
         self.buffer.set_text(text);
@@ -365,7 +566,7 @@ impl Editor {
         let start = self.buffer.start_iter();
         self.buffer.place_cursor(&start);
         self.last_line.set(0);
-        decorate(&self.buffer);
+        self.refresh();
     }
 
     pub fn text(&self) -> String {
@@ -374,14 +575,12 @@ impl Editor {
             .to_string()
     }
 
-    pub fn connect_changed<F: Fn(&str) + 'static>(&self, callback: F) {
-        *self.on_changed.borrow_mut() = Some(Box::new(callback));
+    pub fn refresh(&self) {
+        decorate(&self.buffer, self.decoration.get());
     }
 
-    /// Posición del cursor como (línea, columna), en base 1.
-    pub fn cursor_position(&self) -> (i32, i32) {
-        let iter = self.buffer.iter_at_offset(self.buffer.cursor_position());
-        (iter.line() + 1, iter.line_offset() + 1)
+    pub fn connect_changed<F: Fn(&str) + 'static>(&self, callback: F) {
+        *self.on_changed.borrow_mut() = Some(Box::new(callback));
     }
 
     pub fn connect_cursor_moved<F: Fn() + 'static>(&self, callback: F) {
@@ -389,18 +588,25 @@ impl Editor {
             .connect_cursor_position_notify(move |_| callback());
     }
 
-    pub fn set_style(&self, font_size: i32, line_spacing: f64) {
-        let size = font_size.clamp(9, 40);
-        self.css.load_from_string(&format!(
-            "textview.scribe-editor {{ \
-                font-family: Cantarell, 'Adwaita Sans', 'Noto Sans', sans-serif; \
-                font-size: {size}px; \
-             }}"
-        ));
-        let extra = ((size as f64) * (line_spacing - 1.0)).round().max(0.0) as i32;
-        self.view.set_pixels_above_lines(extra / 2);
-        self.view.set_pixels_below_lines(extra / 2);
-        self.view.set_pixels_inside_wrap(extra / 3);
+    pub fn cursor_position(&self) -> (i32, i32) {
+        let iter = self.buffer.iter_at_offset(self.buffer.cursor_position());
+        (iter.line() + 1, iter.line_offset() + 1)
+    }
+
+    pub fn line_count(&self) -> i32 {
+        self.buffer.end_iter().line() + 1
+    }
+
+    pub fn go_to_line(&self, line: i32) {
+        self.scroll_to_line((line - 1).max(0));
+    }
+
+    pub fn scroll_to_line(&self, line: i32) {
+        if let Some(mut iter) = self.buffer.iter_at_line(line) {
+            self.buffer.place_cursor(&iter);
+            self.view.scroll_to_iter(&mut iter, 0.0, true, 0.0, 0.3);
+            self.view.grab_focus();
+        }
     }
 
     /// Envuelve la selección con un marcador (`**`, `*`, `` ` ``…).
@@ -420,16 +626,67 @@ impl Editor {
         self.buffer
             .insert(&mut at, &format!("{marker}{selected}{marker}"));
         self.buffer.end_user_action();
-        let cursor = self.buffer.iter_at_offset(offset + marker.len() as i32);
+        let cursor = self
+            .buffer
+            .iter_at_offset(offset + marker.chars().count() as i32);
         self.buffer.place_cursor(&cursor);
         self.view.grab_focus();
     }
 
-    pub fn scroll_to_line(&self, line: i32) {
-        if let Some(mut iter) = self.buffer.iter_at_line(line) {
-            self.buffer.place_cursor(&iter);
-            self.view.scroll_to_iter(&mut iter, 0.0, true, 0.0, 0.25);
-            self.view.grab_focus();
+    // --- apariencia y comportamiento -------------------------------------
+
+    pub fn set_font(&self, family: FontFamily, size: i32, line_spacing: f64) {
+        let size = size.clamp(9, 40);
+        self.css.load_from_string(&format!(
+            "textview.scribe-editor {{ font-family: {}; font-size: {size}px; }}",
+            family.css_stack()
+        ));
+        let extra = ((size as f64) * (line_spacing - 1.0)).round().max(0.0) as i32;
+        self.view.set_pixels_above_lines(extra / 2);
+        self.view.set_pixels_below_lines(extra / 2);
+        self.view.set_pixels_inside_wrap(extra / 3);
+    }
+
+    pub fn set_column_width(&self, width: i32) {
+        self.column_width.set(width.clamp(480, 1400));
+        if let Some(hadj) = self.view.hadjustment() {
+            let available = hadj.page_size() as i32;
+            let margin = ((available - self.column_width.get()) / 2).max(MIN_MARGIN);
+            self.view.set_left_margin(margin);
+            self.view.set_right_margin(margin);
+            set_column_margins(&self.tags, margin);
         }
+    }
+
+    pub fn set_markup_visibility(&self, visibility: MarkupVisibility) {
+        let mut config = self.decoration.get();
+        config.markup = visibility;
+        self.decoration.set(config);
+        self.refresh();
+    }
+
+    pub fn set_focus_mode(&self, enabled: bool) {
+        let mut config = self.decoration.get();
+        config.focus_mode = enabled;
+        self.decoration.set(config);
+        self.refresh();
+    }
+
+    pub fn set_typewriter_mode(&self, enabled: bool) {
+        self.typewriter.set(enabled);
+        if enabled {
+            self.view
+                .scroll_to_mark(&self.buffer.get_insert(), 0.0, true, 0.0, 0.5);
+        }
+    }
+
+    pub fn set_continue_lists(&self, enabled: bool) {
+        self.continue_lists.set(enabled);
+    }
+
+    pub fn set_tab_width(&self, width: i32) {
+        let width = width.clamp(2, 8) as u32;
+        self.view.set_tab_width(width);
+        self.view.set_indent_width(width as i32);
     }
 }

--- a/src/file_manager.rs
+++ b/src/file_manager.rs
@@ -20,14 +20,8 @@ impl FileManager {
         Self
     }
 
-    pub fn open<F: Fn(OpenOutcome) + 'static>(
-        &self,
-        parent: &impl IsA<gtk4::Window>,
-        callback: F,
-    ) {
-        let dialog = gtk4::FileDialog::builder()
-            .title("Abrir documento")
-            .build();
+    pub fn open<F: Fn(OpenOutcome) + 'static>(&self, parent: &impl IsA<gtk4::Window>, callback: F) {
+        let dialog = gtk4::FileDialog::builder().title("Abrir documento").build();
 
         let filter = gtk4::FileFilter::new();
         filter.add_suffix("md");
@@ -39,23 +33,19 @@ impl FileManager {
         filters.append(&filter);
         dialog.set_filters(Some(&filters));
 
-        dialog.open(
-            Some(parent),
-            gio::Cancellable::NONE,
-            move |result| {
-                let outcome = match result {
-                    Ok(file) => match file.path() {
-                        Some(path) => match std::fs::read_to_string(&path) {
-                            Ok(content) => OpenOutcome::Ok((path, content)),
-                            Err(e) => OpenOutcome::Error(e.to_string()),
-                        },
-                        None => OpenOutcome::Cancelled,
+        dialog.open(Some(parent), gio::Cancellable::NONE, move |result| {
+            let outcome = match result {
+                Ok(file) => match file.path() {
+                    Some(path) => match std::fs::read_to_string(&path) {
+                        Ok(content) => OpenOutcome::Ok((path, content)),
+                        Err(e) => OpenOutcome::Error(e.to_string()),
                     },
-                    Err(e) => OpenOutcome::Error(e.to_string()),
-                };
-                callback(outcome);
-            },
-        );
+                    None => OpenOutcome::Cancelled,
+                },
+                Err(e) => OpenOutcome::Error(e.to_string()),
+            };
+            callback(outcome);
+        });
     }
 
     pub fn save<F: Fn(Outcome) + 'static>(
@@ -92,22 +82,18 @@ impl FileManager {
         }
 
         let content = content.to_string();
-        dialog.save(
-            Some(parent),
-            gio::Cancellable::NONE,
-            move |result| {
-                let outcome = match result {
-                    Ok(file) => match file.path() {
-                        Some(path) => match std::fs::write(&path, &content) {
-                            Ok(()) => Outcome::Ok(path),
-                            Err(e) => Outcome::Error(e.to_string()),
-                        },
-                        None => Outcome::Cancelled,
+        dialog.save(Some(parent), gio::Cancellable::NONE, move |result| {
+            let outcome = match result {
+                Ok(file) => match file.path() {
+                    Some(path) => match std::fs::write(&path, &content) {
+                        Ok(()) => Outcome::Ok(path),
+                        Err(e) => Outcome::Error(e.to_string()),
                     },
-                    Err(e) => Outcome::Error(e.to_string()),
-                };
-                callback(outcome);
-            },
-        );
+                    None => Outcome::Cancelled,
+                },
+                Err(e) => Outcome::Error(e.to_string()),
+            };
+            callback(outcome);
+        });
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,46 +1,94 @@
 use gtk4::prelude::*;
 use libadwaita as adw;
-
 use std::rc::Rc;
 
-mod window;
 mod editor;
+mod file_manager;
 mod markdown_render;
+mod preferences;
 mod preview;
 mod settings;
-mod file_manager;
+mod templates;
+mod window;
 
-use window::ScribeWindow;
 use settings::AppSettings;
+use window::ScribeWindow;
 
 const APP_ID: &str = "app.scribe.Scribe";
 
-fn main() {
+fn main() -> glib::ExitCode {
     let app = adw::Application::builder()
         .application_id(APP_ID)
+        // Necesario para que `scribe fichero.md` y «Abrir con» funcionen.
+        .flags(gio::ApplicationFlags::HANDLES_OPEN)
         .build();
 
     app.connect_startup(|app| {
-        app.set_accels_for_action("win.open", &["<Ctrl>o"]);
-        app.set_accels_for_action("win.save", &["<Ctrl>s"]);
-        app.set_accels_for_action("win.save-as", &["<Ctrl><Shift>s"]);
-        app.set_accels_for_action("win.new-window", &["<Ctrl>n"]);
-        app.set_accels_for_action("win.toggle-sidebar", &["F9"]);
-        app.set_accels_for_action("win.toggle-preview", &["<Ctrl><Shift>p"]);
-        app.set_accels_for_action("win.bold", &["<Ctrl>b"]);
-        app.set_accels_for_action("win.italic", &["<Ctrl>i"]);
-        app.set_accels_for_action("win.code", &["<Ctrl>k"]);
-        app.set_accels_for_action("win.preferences", &["<Ctrl>comma"]);
-        app.set_accels_for_action("win.show-help-overlay", &["<Ctrl>question"]);
-        app.set_accels_for_action("app.quit", &["<Ctrl>q"]);
+        templates::ensure_defaults();
+
+        // Las acciones app.* deben existir: si no, las entradas del menú
+        // salen grises y los aceleradores no hacen nada.
+        let quit = gio::SimpleAction::new("quit", None);
+        let weak = app.downgrade();
+        quit.connect_activate(move |_, _| {
+            if let Some(app) = weak.upgrade() {
+                app.quit();
+            }
+        });
+        app.add_action(&quit);
+
+        let new_window = gio::SimpleAction::new("new-window", None);
+        let weak = app.downgrade();
+        new_window.connect_activate(move |_, _| {
+            if let Some(app) = weak.upgrade() {
+                build_window(&app).present();
+            }
+        });
+        app.add_action(&new_window);
+
+        for (action, accels) in [
+            ("win.new-document", &["<Ctrl>n"][..]),
+            ("win.open", &["<Ctrl>o"]),
+            ("win.save", &["<Ctrl>s"]),
+            ("win.save-as", &["<Ctrl><Shift>s"]),
+            ("app.new-window", &["<Ctrl><Shift>n"]),
+            ("app.quit", &["<Ctrl>q"]),
+            ("win.bold", &["<Ctrl>b"]),
+            ("win.italic", &["<Ctrl>i"]),
+            ("win.code", &["<Ctrl>k"]),
+            ("win.toggle-sidebar", &["F9"]),
+            ("win.toggle-preview", &["<Ctrl><Shift>p"]),
+            ("win.focus-mode", &["<Ctrl><Shift>f"]),
+            ("win.typewriter-mode", &["<Ctrl><Shift>t"]),
+            (
+                "win.zoom-in",
+                &["<Ctrl>plus", "<Ctrl>equal", "<Ctrl>KP_Add"],
+            ),
+            ("win.zoom-out", &["<Ctrl>minus", "<Ctrl>KP_Subtract"]),
+            ("win.zoom-reset", &["<Ctrl>0"]),
+            ("win.preferences", &["<Ctrl>comma"]),
+            ("win.show-help-overlay", &["<Ctrl>question"]),
+        ] {
+            app.set_accels_for_action(action, accels);
+        }
     });
 
-    app.connect_activate(build_ui);
-    app.run();
+    app.connect_activate(|app| build_window(app).present());
+
+    app.connect_open(|app, files, _hint| {
+        for file in files {
+            let win = build_window(app);
+            if let Some(path) = file.path() {
+                win.open_path(&path);
+            }
+            win.present();
+        }
+    });
+
+    app.run()
 }
 
-fn build_ui(app: &adw::Application) {
+fn build_window(app: &adw::Application) -> ScribeWindow {
     let settings = Rc::new(AppSettings::new());
-    let win = ScribeWindow::new(app, &settings);
-    win.present();
+    ScribeWindow::new(app, &settings)
 }

--- a/src/markdown_render.rs
+++ b/src/markdown_render.rs
@@ -7,7 +7,7 @@
 //! backticks, la URL de un enlace…). El editor las oculta salvo cuando el cursor
 //! está en su línea, que es lo que hace que la edición se sienta WYSIWYG.
 
-use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag, TagEnd};
+use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, LinkType, Options, Parser, Tag, TagEnd};
 
 /// Por encima de este tamaño se deja de decorar en vivo, para no bloquear la UI.
 pub const MAX_LIVE_BYTES: usize = 400_000;
@@ -144,6 +144,20 @@ pub fn spans(text: &str) -> Vec<Span> {
                 if hashes > 0 {
                     let spaces = src[hashes..].bytes().take_while(|b| *b == b' ').count();
                     out.push(syn(range.start, range.start + hashes + spaces));
+                } else {
+                    // Cabecera setext: se oculta el subrayado `===` / `---`
+                    // junto con el salto de línea que lo separa del título,
+                    // para que no quede un renglón en blanco.
+                    let lines = line_ranges(text, range.start, end);
+                    if let Some(&(ls, le)) = lines.last() {
+                        let underline = text[ls..le].trim();
+                        let is_rule = !underline.is_empty()
+                            && (underline.bytes().all(|b| b == b'=')
+                                || underline.bytes().all(|b| b == b'-'));
+                        if is_rule && ls > range.start {
+                            out.push(syn(ls - 1, le));
+                        }
+                    }
                 }
             }
 
@@ -169,13 +183,24 @@ pub fn spans(text: &str) -> Vec<Span> {
                 mark_delims(&mut out, range.start, range.end, ticks);
             }
 
-            Event::Start(Tag::Link { .. }) => {
+            Event::Start(Tag::Link { link_type, .. }) => {
                 out.push(style(range.start, range.end, "link"));
                 let src = &text[range.start..range.end];
-                if src.starts_with('[') {
-                    if let Some(idx) = src.rfind("](") {
-                        out.push(syn(range.start, range.start + 1));
-                        out.push(syn(range.start + idx, range.end));
+                match link_type {
+                    // `<https://…>` y `<a@b.com>`: solo sobran los ángulos.
+                    LinkType::Autolink | LinkType::Email => {
+                        if src.starts_with('<') && src.ends_with('>') && src.len() > 2 {
+                            out.push(syn(range.start, range.start + 1));
+                            out.push(syn(range.end - 1, range.end));
+                        }
+                    }
+                    _ => {
+                        if src.starts_with('[') {
+                            if let Some(idx) = src.rfind("](") {
+                                out.push(syn(range.start, range.start + 1));
+                                out.push(syn(range.start + idx, range.end));
+                            }
+                        }
                     }
                 }
             }
@@ -235,6 +260,29 @@ pub fn spans(text: &str) -> Vec<Span> {
                     }
                 }
             }
+
+            Event::Start(Tag::Table(_)) => {
+                // Monoespaciada en todo el bloque: si el usuario alinea los
+                // pipes en el fuente, las columnas cuadran también en pantalla.
+                let end = trim_nl(text, range.end);
+                out.push(style(range.start, end, "table"));
+                for (ls, le) in line_ranges(text, range.start, end) {
+                    let line = text[ls..le].trim();
+                    let is_delimiter = !line.is_empty()
+                        && line.bytes().all(|b| matches!(b, b'|' | b'-' | b':' | b' '))
+                        && line.contains('-');
+                    if is_delimiter {
+                        out.push(style(ls, le, "tabledelim"));
+                        break;
+                    }
+                }
+            }
+
+            Event::Html(_) | Event::InlineHtml(_) => {
+                out.push(style(range.start, trim_nl(text, range.end), "html"))
+            }
+            Event::FootnoteReference(_) => out.push(style(range.start, range.end, "footnote")),
+            Event::HardBreak => out.push(syn(range.start, trim_nl(text, range.end))),
 
             Event::Rule => out.push(style(range.start, trim_nl(text, range.end), "rule")),
             Event::TaskListMarker(_) => out.push(style(range.start, range.end, "task")),
@@ -344,6 +392,25 @@ mod tests {
             assert!(text.is_char_boundary(s.start), "{s:?}");
             assert!(text.is_char_boundary(s.end), "{s:?}");
         }
+    }
+
+    #[test]
+    fn cabecera_setext_oculta_el_subrayado() {
+        let s = spans("Título\n======\n");
+        assert_eq!(find(&s, "h1").len(), 1);
+        assert_eq!(hidden("Título\n======\n"), "Título\n");
+    }
+
+    #[test]
+    fn enlace_automatico_oculta_los_angulos() {
+        assert_eq!(hidden("ver <https://ej.com> ya"), "ver https://ej.com ya");
+    }
+
+    #[test]
+    fn tabla_va_en_monoespaciada() {
+        let s = spans("| a | b |\n|---|---|\n| 1 | 2 |\n");
+        assert_eq!(find(&s, "table").len(), 1);
+        assert_eq!(find(&s, "tabledelim").len(), 1);
     }
 
     #[test]

--- a/src/preferences.rs
+++ b/src/preferences.rs
@@ -1,0 +1,375 @@
+//! Ventana de preferencias (AdwPreferencesWindow), organizada por páginas
+//! según las HIG de GNOME: apariencia, editor y plantillas.
+
+use gtk4::prelude::*;
+use libadwaita as adw;
+use libadwaita::prelude::*;
+use std::rc::Rc;
+
+use crate::settings::{AppSettings, FontFamily, MarkupVisibility};
+use crate::templates;
+
+fn spin(title: &str, subtitle: &str, adj: &gtk4::Adjustment, digits: u32) -> adw::SpinRow {
+    adw::SpinRow::builder()
+        .title(title)
+        .subtitle(subtitle)
+        .adjustment(adj)
+        .digits(digits)
+        .build()
+}
+
+fn combo(title: &str, subtitle: &str, options: &[&str], selected: u32) -> adw::ComboRow {
+    adw::ComboRow::builder()
+        .title(title)
+        .subtitle(subtitle)
+        .model(&gtk4::StringList::new(options))
+        .selected(selected)
+        .build()
+}
+
+/// `apply` se invoca tras cada cambio para que la ventana relea los ajustes.
+pub fn present(parent: &adw::ApplicationWindow, settings: &Rc<AppSettings>, apply: Rc<dyn Fn()>) {
+    let window = adw::PreferencesWindow::builder()
+        .transient_for(parent)
+        .modal(true)
+        .search_enabled(true)
+        .build();
+
+    window.add(&appearance_page(settings, &apply));
+    window.add(&editor_page(settings, &apply));
+    window.add(&templates_page(parent, settings, &apply));
+    window.present();
+}
+
+fn appearance_page(settings: &Rc<AppSettings>, apply: &Rc<dyn Fn()>) -> adw::PreferencesPage {
+    let page = adw::PreferencesPage::builder()
+        .title("Apariencia")
+        .icon_name("preferences-desktop-appearance-symbolic")
+        .build();
+
+    let theme_group = adw::PreferencesGroup::builder().title("Tema").build();
+    let theme = combo(
+        "Esquema de color",
+        "Sigue al sistema salvo que fuerces uno",
+        &["Sistema", "Claro", "Oscuro"],
+        settings.color_scheme_index(),
+    );
+    theme_group.add(&theme);
+    page.add(&theme_group);
+
+    let text_group = adw::PreferencesGroup::builder()
+        .title("Texto")
+        .description("El código y las tablas usan siempre monoespaciada")
+        .build();
+
+    let family = combo(
+        "Familia tipográfica",
+        "Cuerpo del documento",
+        &["Sans (Cantarell)", "Serif", "Monoespaciada"],
+        settings.font_family().index(),
+    );
+    let size = spin(
+        "Tamaño",
+        "Píxeles",
+        &gtk4::Adjustment::new(settings.font_size() as f64, 9.0, 40.0, 1.0, 2.0, 0.0),
+        0,
+    );
+    let spacing = spin(
+        "Interlineado",
+        "Multiplicador sobre el tamaño de fuente",
+        &gtk4::Adjustment::new(settings.line_spacing(), 1.0, 3.0, 0.1, 0.1, 0.0),
+        1,
+    );
+    let column = spin(
+        "Ancho de la columna",
+        "Ancho máximo del texto, en píxeles",
+        &gtk4::Adjustment::new(
+            settings.column_width() as f64,
+            480.0,
+            1400.0,
+            20.0,
+            50.0,
+            0.0,
+        ),
+        0,
+    );
+    for row in [&size, &spacing, &column] {
+        text_group.add(row);
+    }
+    text_group.add(&family);
+    page.add(&text_group);
+
+    {
+        let settings = settings.clone();
+        let apply = apply.clone();
+        theme.connect_selected_notify(move |row| {
+            settings.set_color_scheme_index(row.selected());
+            apply();
+        });
+    }
+    {
+        let settings = settings.clone();
+        let apply = apply.clone();
+        family.connect_selected_notify(move |row| {
+            settings.set_font_family(FontFamily::from_index(row.selected()));
+            apply();
+        });
+    }
+    {
+        let settings = settings.clone();
+        let apply = apply.clone();
+        size.connect_value_notify(move |row| {
+            settings.set_font_size(row.value() as i32);
+            apply();
+        });
+    }
+    {
+        let settings = settings.clone();
+        let apply = apply.clone();
+        spacing.connect_value_notify(move |row| {
+            settings.set_line_spacing(row.value());
+            apply();
+        });
+    }
+    {
+        let settings = settings.clone();
+        let apply = apply.clone();
+        column.connect_value_notify(move |row| {
+            settings.set_column_width(row.value() as i32);
+            apply();
+        });
+    }
+
+    page
+}
+
+fn editor_page(settings: &Rc<AppSettings>, apply: &Rc<dyn Fn()>) -> adw::PreferencesPage {
+    let page = adw::PreferencesPage::builder()
+        .title("Editor")
+        .icon_name("document-edit-symbolic")
+        .build();
+
+    let markup_group = adw::PreferencesGroup::builder()
+        .title("Marcado")
+        .description("Qué hacer con los asteriscos, almohadillas y URLs mientras escribes")
+        .build();
+    let markup = combo(
+        "Marcas de Markdown",
+        "«Al enfocar» las revela solo en la línea del cursor",
+        &["Ocultar siempre", "Mostrar al enfocar", "Atenuar siempre"],
+        settings.markup_visibility().index(),
+    );
+    markup_group.add(&markup);
+    page.add(&markup_group);
+
+    let writing_group = adw::PreferencesGroup::builder().title("Escritura").build();
+    let lists = adw::SwitchRow::builder()
+        .title("Continuar listas")
+        .subtitle("Intro repite el guion o el número; en un elemento vacío, cierra la lista")
+        .active(settings.continue_lists())
+        .build();
+    let focus = adw::SwitchRow::builder()
+        .title("Modo foco")
+        .subtitle("Atenúa todo salvo el párrafo actual")
+        .active(settings.focus_mode())
+        .build();
+    let typewriter = adw::SwitchRow::builder()
+        .title("Máquina de escribir")
+        .subtitle("Mantiene la línea del cursor centrada verticalmente")
+        .active(settings.typewriter_mode())
+        .build();
+    let tabs = spin(
+        "Ancho de tabulación",
+        "Espacios por nivel de sangría",
+        &gtk4::Adjustment::new(settings.tab_width() as f64, 2.0, 8.0, 1.0, 1.0, 0.0),
+        0,
+    );
+    for row in [&lists, &focus, &typewriter] {
+        writing_group.add(row);
+    }
+    writing_group.add(&tabs);
+    page.add(&writing_group);
+
+    let save_group = adw::PreferencesGroup::builder().title("Guardado").build();
+    let autosave = adw::SwitchRow::builder()
+        .title("Guardado automático")
+        .subtitle("Solo si el documento ya tiene un fichero asociado")
+        .active(settings.autosave())
+        .build();
+    let interval = spin(
+        "Intervalo",
+        "Segundos entre guardados",
+        &gtk4::Adjustment::new(
+            settings.autosave_interval() as f64,
+            5.0,
+            600.0,
+            5.0,
+            15.0,
+            0.0,
+        ),
+        0,
+    );
+    interval.set_sensitive(settings.autosave());
+    save_group.add(&autosave);
+    save_group.add(&interval);
+    page.add(&save_group);
+
+    {
+        let settings = settings.clone();
+        let apply = apply.clone();
+        markup.connect_selected_notify(move |row| {
+            settings.set_markup_visibility(MarkupVisibility::from_index(row.selected()));
+            apply();
+        });
+    }
+    for (row, setter) in [
+        (
+            &lists,
+            Box::new(|s: &AppSettings, v: bool| s.set_continue_lists(v))
+                as Box<dyn Fn(&AppSettings, bool)>,
+        ),
+        (
+            &focus,
+            Box::new(|s: &AppSettings, v: bool| s.set_focus_mode(v)),
+        ),
+        (
+            &typewriter,
+            Box::new(|s: &AppSettings, v: bool| s.set_typewriter_mode(v)),
+        ),
+    ] {
+        let settings = settings.clone();
+        let apply = apply.clone();
+        row.connect_active_notify(move |row| {
+            setter(&settings, row.is_active());
+            apply();
+        });
+    }
+    {
+        let settings = settings.clone();
+        let apply = apply.clone();
+        tabs.connect_value_notify(move |row| {
+            settings.set_tab_width(row.value() as i32);
+            apply();
+        });
+    }
+    {
+        let settings = settings.clone();
+        let apply = apply.clone();
+        let interval_row = interval.clone();
+        autosave.connect_active_notify(move |row| {
+            settings.set_autosave(row.is_active());
+            interval_row.set_sensitive(row.is_active());
+            apply();
+        });
+    }
+    {
+        let settings = settings.clone();
+        let apply = apply.clone();
+        interval.connect_value_notify(move |row| {
+            settings.set_autosave_interval(row.value() as i32);
+            apply();
+        });
+    }
+
+    page
+}
+
+fn templates_page(
+    parent: &adw::ApplicationWindow,
+    settings: &Rc<AppSettings>,
+    apply: &Rc<dyn Fn()>,
+) -> adw::PreferencesPage {
+    let page = adw::PreferencesPage::builder()
+        .title("Plantillas")
+        .icon_name("document-new-symbolic")
+        .build();
+
+    let list = templates::list();
+    let mut names: Vec<&str> = vec!["Documento en blanco"];
+    names.extend(list.iter().map(|t| t.name.as_str()));
+    let current = settings.default_template();
+    let selected = list
+        .iter()
+        .position(|t| t.name == current)
+        .map(|i| i as u32 + 1)
+        .unwrap_or(0);
+
+    let group = adw::PreferencesGroup::builder()
+        .title("Documentos nuevos")
+        .description(
+            "Las plantillas son ficheros .md en tu carpeta de datos. \
+             Admiten {{title}}, {{date}}, {{time}}, {{datetime}} y {{year}}.",
+        )
+        .build();
+
+    let default_row = combo(
+        "Plantilla por defecto",
+        "Se usa al crear un documento nuevo",
+        &names,
+        selected,
+    );
+    group.add(&default_row);
+
+    let open_button = gtk4::Button::builder()
+        .icon_name("folder-open-symbolic")
+        .valign(gtk4::Align::Center)
+        .css_classes(vec!["flat".to_string()])
+        .tooltip_text("Abrir la carpeta")
+        .build();
+    let folder_row = adw::ActionRow::builder()
+        .title("Carpeta de plantillas")
+        .subtitle(templates::dir().to_string_lossy().as_ref())
+        .activatable_widget(&open_button)
+        .build();
+    folder_row.add_suffix(&open_button);
+    group.add(&folder_row);
+    page.add(&group);
+
+    let recents_group = adw::PreferencesGroup::builder().title("Historial").build();
+    let clear_button = gtk4::Button::builder()
+        .label("Vaciar")
+        .valign(gtk4::Align::Center)
+        .css_classes(vec!["destructive-action".to_string()])
+        .build();
+    let clear_row = adw::ActionRow::builder()
+        .title("Documentos recientes")
+        .subtitle("Borra la lista que aparece en la barra lateral")
+        .activatable_widget(&clear_button)
+        .build();
+    clear_row.add_suffix(&clear_button);
+    recents_group.add(&clear_row);
+    page.add(&recents_group);
+
+    {
+        let settings = settings.clone();
+        let apply = apply.clone();
+        default_row.connect_selected_notify(move |row| {
+            let index = row.selected() as usize;
+            let name = if index == 0 {
+                String::new()
+            } else {
+                templates::list()
+                    .get(index - 1)
+                    .map(|t| t.name.clone())
+                    .unwrap_or_default()
+            };
+            settings.set_default_template(&name);
+            apply();
+        });
+    }
+    {
+        let parent = parent.clone();
+        open_button.connect_clicked(move |_| templates::open_dir(&parent));
+    }
+    {
+        let settings = settings.clone();
+        let apply = apply.clone();
+        clear_button.connect_clicked(move |button| {
+            settings.clear_recent_files();
+            button.set_sensitive(false);
+            apply();
+        });
+    }
+
+    page
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,57 +1,282 @@
 use gio::prelude::*;
 
+/// Cuándo se muestran las marcas de Markdown (`**`, `#`, backticks, URLs).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MarkupVisibility {
+    /// Siempre ocultas.
+    Hidden,
+    /// Ocultas salvo en la línea del cursor.
+    Focus,
+    /// Siempre visibles, pero atenuadas.
+    Dim,
+}
+
+impl MarkupVisibility {
+    fn from_nick(nick: &str) -> Self {
+        match nick {
+            "hidden" => Self::Hidden,
+            "dim" => Self::Dim,
+            _ => Self::Focus,
+        }
+    }
+    pub fn nick(self) -> &'static str {
+        match self {
+            Self::Hidden => "hidden",
+            Self::Focus => "focus",
+            Self::Dim => "dim",
+        }
+    }
+    pub fn index(self) -> u32 {
+        match self {
+            Self::Hidden => 0,
+            Self::Focus => 1,
+            Self::Dim => 2,
+        }
+    }
+    pub fn from_index(i: u32) -> Self {
+        match i {
+            0 => Self::Hidden,
+            2 => Self::Dim,
+            _ => Self::Focus,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FontFamily {
+    Sans,
+    Serif,
+    Mono,
+}
+
+impl FontFamily {
+    fn from_nick(nick: &str) -> Self {
+        match nick {
+            "serif" => Self::Serif,
+            "mono" => Self::Mono,
+            _ => Self::Sans,
+        }
+    }
+    pub fn nick(self) -> &'static str {
+        match self {
+            Self::Sans => "sans",
+            Self::Serif => "serif",
+            Self::Mono => "mono",
+        }
+    }
+    pub fn index(self) -> u32 {
+        match self {
+            Self::Sans => 0,
+            Self::Serif => 1,
+            Self::Mono => 2,
+        }
+    }
+    pub fn from_index(i: u32) -> Self {
+        match i {
+            1 => Self::Serif,
+            2 => Self::Mono,
+            _ => Self::Sans,
+        }
+    }
+    /// Pila de familias CSS. El cuerpo va en proporcional; la monoespaciada
+    /// queda reservada para el código aunque se elija "mono" como cuerpo.
+    pub fn css_stack(self) -> &'static str {
+        match self {
+            Self::Sans => "Cantarell, 'Adwaita Sans', 'Noto Sans', sans-serif",
+            Self::Serif => "'Source Serif 4', 'Noto Serif', 'Liberation Serif', serif",
+            Self::Mono => "'Adwaita Mono', 'Source Code Pro', 'Fira Mono', monospace",
+        }
+    }
+}
+
 pub struct AppSettings {
     settings: Option<gio::Settings>,
+}
+
+macro_rules! prop {
+    ($get:ident, $set:ident, $key:literal, i32, $default:expr) => {
+        pub fn $get(&self) -> i32 {
+            self.get($default, |s| s.int($key))
+        }
+        pub fn $set(&self, v: i32) {
+            self.set(|s| {
+                let _ = s.set_int($key, v);
+            });
+        }
+    };
+    ($get:ident, $set:ident, $key:literal, f64, $default:expr) => {
+        pub fn $get(&self) -> f64 {
+            self.get($default, |s| s.double($key))
+        }
+        pub fn $set(&self, v: f64) {
+            self.set(|s| {
+                let _ = s.set_double($key, v);
+            });
+        }
+    };
+    ($get:ident, $set:ident, $key:literal, bool, $default:expr) => {
+        pub fn $get(&self) -> bool {
+            self.get($default, |s| s.boolean($key))
+        }
+        pub fn $set(&self, v: bool) {
+            self.set(|s| {
+                let _ = s.set_boolean($key, v);
+            });
+        }
+    };
+    ($get:ident, $set:ident, $key:literal, String, $default:expr) => {
+        pub fn $get(&self) -> String {
+            self.get($default.to_string(), |s| s.string($key).to_string())
+        }
+        pub fn $set(&self, v: &str) {
+            self.set(|s| {
+                let _ = s.set_string($key, v);
+            });
+        }
+    };
 }
 
 impl AppSettings {
     pub fn new() -> Self {
         let settings = gio::SettingsSchemaSource::default()
-            .and_then(|source| source.lookup("app.scribe.Scribe", false))
+            .and_then(|source| source.lookup("app.scribe.Scribe", true))
             .map(|_| gio::Settings::new("app.scribe.Scribe"));
+        if settings.is_none() {
+            eprintln!(
+                "scribe: no se encontró el esquema GSettings 'app.scribe.Scribe'. \
+                 Se usan los valores por defecto y no se guardarán las preferencias. \
+                 En desarrollo: glib-compile-schemas data/ && \
+                 GSETTINGS_SCHEMA_DIR=$PWD/data cargo run"
+            );
+        }
         Self { settings }
     }
 
-    fn get<T: Clone>(&self, key: &str, default: T, f: impl FnOnce(&gio::Settings) -> T) -> T {
+    fn get<T>(&self, default: T, f: impl FnOnce(&gio::Settings) -> T) -> T {
         self.settings.as_ref().map(f).unwrap_or(default)
     }
 
-    pub fn window_width(&self) -> i32 { self.get("window-width", 1100, |s| s.int("window-width")) }
-    pub fn set_window_width(&self, v: i32) { if let Some(s) = &self.settings { let _ = s.set_int("window-width", v); } }
+    fn set(&self, f: impl FnOnce(&gio::Settings)) {
+        if let Some(s) = &self.settings {
+            f(s);
+        }
+    }
 
-    pub fn window_height(&self) -> i32 { self.get("window-height", 800, |s| s.int("window-height")) }
-    pub fn set_window_height(&self, v: i32) { if let Some(s) = &self.settings { let _ = s.set_int("window-height", v); } }
+    prop!(window_width, set_window_width, "window-width", i32, 1100);
+    prop!(window_height, set_window_height, "window-height", i32, 800);
+    prop!(
+        window_maximized,
+        set_window_maximized,
+        "window-maximized",
+        bool,
+        false
+    );
+    prop!(show_sidebar, set_show_sidebar, "show-sidebar", bool, false);
+    prop!(show_preview, set_show_preview, "show-preview", bool, false);
+    prop!(font_size, set_font_size, "font-size", i32, 16);
+    prop!(line_spacing, set_line_spacing, "line-spacing", f64, 1.7);
+    prop!(column_width, set_column_width, "column-width", i32, 720);
+    prop!(focus_mode, set_focus_mode, "focus-mode", bool, false);
+    prop!(
+        typewriter_mode,
+        set_typewriter_mode,
+        "typewriter-mode",
+        bool,
+        false
+    );
+    prop!(
+        continue_lists,
+        set_continue_lists,
+        "continue-lists",
+        bool,
+        true
+    );
+    prop!(tab_width, set_tab_width, "tab-width", i32, 4);
+    prop!(autosave, set_autosave, "autosave", bool, true);
+    prop!(
+        autosave_interval,
+        set_autosave_interval,
+        "autosave-interval",
+        i32,
+        30
+    );
+    prop!(
+        default_template,
+        set_default_template,
+        "default-template",
+        String,
+        ""
+    );
 
-    pub fn show_sidebar(&self) -> bool { self.get("show-sidebar", false, |s| s.boolean("show-sidebar")) }
-    pub fn set_show_sidebar(&self, v: bool) { if let Some(s) = &self.settings { let _ = s.set_boolean("show-sidebar", v); } }
+    pub fn markup_visibility(&self) -> MarkupVisibility {
+        MarkupVisibility::from_nick(&self.get("focus".to_string(), |s| {
+            s.string("markup-visibility").to_string()
+        }))
+    }
+    pub fn set_markup_visibility(&self, v: MarkupVisibility) {
+        self.set(|s| {
+            let _ = s.set_string("markup-visibility", v.nick());
+        });
+    }
 
-    pub fn show_preview(&self) -> bool { self.get("show-preview", false, |s| s.boolean("show-preview")) }
-    pub fn set_show_preview(&self, v: bool) { if let Some(s) = &self.settings { let _ = s.set_boolean("show-preview", v); } }
+    pub fn font_family(&self) -> FontFamily {
+        FontFamily::from_nick(
+            &self.get("sans".to_string(), |s| s.string("font-family").to_string()),
+        )
+    }
+    pub fn set_font_family(&self, v: FontFamily) {
+        self.set(|s| {
+            let _ = s.set_string("font-family", v.nick());
+        });
+    }
 
-    pub fn autosave(&self) -> bool { self.get("autosave", true, |s| s.boolean("autosave")) }
-    pub fn set_autosave(&self, v: bool) { if let Some(s) = &self.settings { let _ = s.set_boolean("autosave", v); } }
-    pub fn font_size(&self) -> i32 { self.get("font-size", 16, |s| s.int("font-size")) }
-    pub fn set_font_size(&self, v: i32) { if let Some(s) = &self.settings { let _ = s.set_int("font-size", v); } }
-    pub fn line_spacing(&self) -> f64 { self.get("line-spacing", 1.7, |s| s.double("line-spacing")) }
-    pub fn set_line_spacing(&self, v: f64) { if let Some(s) = &self.settings { let _ = s.set_double("line-spacing", v); } }
+    /// 0 = sistema, 1 = claro, 2 = oscuro.
+    pub fn color_scheme_index(&self) -> u32 {
+        match self
+            .get("system".to_string(), |s| {
+                s.string("color-scheme").to_string()
+            })
+            .as_str()
+        {
+            "light" => 1,
+            "dark" => 2,
+            _ => 0,
+        }
+    }
+    pub fn set_color_scheme_index(&self, index: u32) {
+        let nick = match index {
+            1 => "light",
+            2 => "dark",
+            _ => "system",
+        };
+        self.set(|s| {
+            let _ = s.set_string("color-scheme", nick);
+        });
+    }
 
     pub fn recent_files(&self) -> Vec<String> {
-        self.get("recent-files", vec![], |s| {
-            s.strv("recent-files").iter().map(|g| g.to_string()).collect()
+        self.get(Vec::new(), |s| {
+            s.strv("recent-files")
+                .iter()
+                .map(|g| g.to_string())
+                .collect()
         })
     }
 
     pub fn push_recent_file(&self, path: &str) {
-        if let Some(s) = &self.settings {
-            let mut list: Vec<String> = vec![path.to_string()];
-            for p in s.strv("recent-files").iter() {
-                let p = p.to_string();
-                if p != path {
-                    list.push(p);
-                }
-            }
-            list.truncate(20);
-            let _ = s.set_strv("recent-files", list);
-        }
+        let mut list = self.recent_files();
+        list.retain(|p| p != path);
+        list.insert(0, path.to_string());
+        list.truncate(20);
+        self.set(|s| {
+            let refs: Vec<&str> = list.iter().map(|s| s.as_str()).collect();
+            let _ = s.set_strv("recent-files", refs);
+        });
+    }
+
+    pub fn clear_recent_files(&self) {
+        self.set(|s| {
+            let _ = s.set_strv("recent-files", Vec::<&str>::new());
+        });
     }
 }

--- a/src/shortcuts.ui
+++ b/src/shortcuts.ui
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <object class="GtkShortcutsWindow" id="help_overlay">
+    <property name="modal">1</property>
+    <child>
+      <object class="GtkShortcutsSection">
+        <property name="section-name">shortcuts</property>
+        <property name="max-height">12</property>
+        <child>
+          <object class="GtkShortcutsGroup">
+            <property name="title">Archivo</property>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title">Documento nuevo</property>
+                <property name="accelerator">&lt;Control&gt;n</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title">Abrir</property>
+                <property name="accelerator">&lt;Control&gt;o</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title">Guardar</property>
+                <property name="accelerator">&lt;Control&gt;s</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title">Guardar como</property>
+                <property name="accelerator">&lt;Control&gt;&lt;Shift&gt;s</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title">Nueva ventana</property>
+                <property name="accelerator">&lt;Control&gt;&lt;Shift&gt;n</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title">Salir</property>
+                <property name="accelerator">&lt;Control&gt;q</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkShortcutsGroup">
+            <property name="title">Formato</property>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title">Negrita</property>
+                <property name="accelerator">&lt;Control&gt;b</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title">Cursiva</property>
+                <property name="accelerator">&lt;Control&gt;i</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title">Código</property>
+                <property name="accelerator">&lt;Control&gt;k</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkShortcutsGroup">
+            <property name="title">Vista</property>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title">Barra lateral</property>
+                <property name="accelerator">F9</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title">Vista dividida</property>
+                <property name="accelerator">&lt;Control&gt;&lt;Shift&gt;p</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title">Modo foco</property>
+                <property name="accelerator">&lt;Control&gt;&lt;Shift&gt;f</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title">Máquina de escribir</property>
+                <property name="accelerator">&lt;Control&gt;&lt;Shift&gt;t</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title">Ampliar o reducir</property>
+                <property name="accelerator">&lt;Control&gt;plus &lt;Control&gt;minus &lt;Control&gt;0</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title">Preferencias</property>
+                <property name="accelerator">&lt;Control&gt;comma</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,0 +1,124 @@
+//! Plantillas para documentos nuevos.
+//!
+//! Son ficheros `.md` sueltos en `$XDG_DATA_HOME/scribe/templates`, así que el
+//! usuario puede añadir, editar o borrar las suyas sin tocar la aplicación.
+//! Admiten un puñado de marcadores que se sustituyen al crear el documento.
+
+use std::path::PathBuf;
+
+pub struct Template {
+    pub name: String,
+    pub path: PathBuf,
+}
+
+impl Template {
+    pub fn body(&self) -> Option<String> {
+        std::fs::read_to_string(&self.path).ok()
+    }
+}
+
+pub fn dir() -> PathBuf {
+    glib::user_data_dir().join("scribe").join("templates")
+}
+
+/// Plantillas que se escriben la primera vez, para que la carpeta no esté vacía.
+const BUILT_IN: [(&str, &str); 4] = [
+    (
+        "Nota",
+        "# {{title}}\n\n*{{date}}*\n\n\n",
+    ),
+    (
+        "Diario",
+        "# {{date}}\n\n## Qué ha pasado\n\n\n\n## Qué he aprendido\n\n\n\n## Mañana\n\n- \n",
+    ),
+    (
+        "Acta de reunión",
+        "# {{title}}\n\n- **Fecha:** {{datetime}}\n- **Asistentes:** \n\n## Temas\n\n1. \n\n## Acuerdos\n\n- \n\n## Tareas\n\n- [ ] \n",
+    ),
+    (
+        "Artículo",
+        "---\ntitle: {{title}}\ndate: {{date}}\ndraft: true\n---\n\n# {{title}}\n\n## Introducción\n\n\n\n## Desarrollo\n\n\n\n## Conclusión\n\n\n",
+    ),
+];
+
+/// Crea la carpeta y escribe las plantillas de ejemplo si aún no existen.
+pub fn ensure_defaults() {
+    let dir = dir();
+    if std::fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+    for (name, body) in BUILT_IN {
+        let path = dir.join(format!("{name}.md"));
+        if !path.exists() {
+            let _ = std::fs::write(&path, body);
+        }
+    }
+}
+
+pub fn list() -> Vec<Template> {
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(dir()) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let is_markdown = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| matches!(e, "md" | "markdown" | "txt"));
+        if !is_markdown {
+            continue;
+        }
+        if let Some(name) = path.file_stem().and_then(|s| s.to_str()) {
+            out.push(Template {
+                name: name.to_string(),
+                path: path.clone(),
+            });
+        }
+    }
+    out.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    out
+}
+
+pub fn find(name: &str) -> Option<Template> {
+    list().into_iter().find(|t| t.name == name)
+}
+
+/// Sustituye los marcadores admitidos: `{{title}}`, `{{date}}`, `{{time}}`,
+/// `{{datetime}}` y `{{year}}`.
+pub fn render(body: &str, title: &str) -> String {
+    let now = glib::DateTime::now_local().ok();
+    let fmt = |pattern: &str| -> String {
+        now.as_ref()
+            .and_then(|d| d.format(pattern).ok())
+            .map(|s| s.to_string())
+            .unwrap_or_default()
+    };
+    body.replace("{{title}}", title)
+        .replace("{{date}}", &fmt("%Y-%m-%d"))
+        .replace("{{time}}", &fmt("%H:%M"))
+        .replace("{{datetime}}", &fmt("%Y-%m-%d %H:%M"))
+        .replace("{{year}}", &fmt("%Y"))
+}
+
+/// Abre la carpeta de plantillas en el gestor de archivos del escritorio.
+pub fn open_dir(parent: &impl gtk4::prelude::IsA<gtk4::Window>) {
+    ensure_defaults();
+    let launcher = gtk4::FileLauncher::new(Some(&gio::File::for_path(dir())));
+    launcher.launch(Some(parent), gio::Cancellable::NONE, |_| {});
+}
+
+/// Nombre de documento sugerido a partir de la primera cabecera del texto.
+pub fn title_from(text: &str) -> Option<String> {
+    for line in text.lines().take(30) {
+        let trimmed = line.trim_start();
+        let hashes = trimmed.bytes().take_while(|b| *b == b'#').count();
+        if (1..=6).contains(&hashes) {
+            let rest = trimmed[hashes..].trim();
+            if !rest.is_empty() {
+                return Some(rest.to_string());
+            }
+        }
+    }
+    None
+}

--- a/src/window.rs
+++ b/src/window.rs
@@ -8,120 +8,31 @@ use std::time::Duration;
 
 use crate::editor::Editor;
 use crate::file_manager::{FileManager, OpenOutcome, Outcome};
+use crate::preferences;
 use crate::preview::PreviewPanel;
 use crate::settings::AppSettings;
+use crate::templates;
 
-const SHORTCUTS_UI: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
-<interface>
-  <object class="GtkShortcutsWindow" id="help_overlay">
-    <property name="modal">1</property>
-    <child>
-      <object class="GtkShortcutsSection">
-        <property name="section-name">shortcuts</property>
-        <property name="max-height">12</property>
-        <child>
-          <object class="GtkShortcutsGroup">
-            <property name="title">Archivo</property>
-            <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title">Abrir</property>
-                <property name="accelerator">&lt;Control&gt;o</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title">Guardar</property>
-                <property name="accelerator">&lt;Control&gt;s</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title">Guardar como</property>
-                <property name="accelerator">&lt;Control&gt;&lt;Shift&gt;s</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title">Nueva ventana</property>
-                <property name="accelerator">&lt;Control&gt;n</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title">Salir</property>
-                <property name="accelerator">&lt;Control&gt;q</property>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkShortcutsGroup">
-            <property name="title">Formato</property>
-            <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title">Negrita</property>
-                <property name="accelerator">&lt;Control&gt;b</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title">Cursiva</property>
-                <property name="accelerator">&lt;Control&gt;i</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title">Código</property>
-                <property name="accelerator">&lt;Control&gt;k</property>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="GtkShortcutsGroup">
-            <property name="title">Vista</property>
-            <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title">Barra lateral</property>
-                <property name="accelerator">F9</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title">Previsualización</property>
-                <property name="accelerator">&lt;Control&gt;&lt;Shift&gt;p</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title">Preferencias</property>
-                <property name="accelerator">&lt;Control&gt;comma</property>
-              </object>
-            </child>
-          </object>
-        </child>
-      </object>
-    </child>
-  </object>
-</interface>"#;
+const SHORTCUTS_UI: &str = include_str!("shortcuts.ui");
+
+/// Crea un documento nuevo, opcionalmente a partir de una plantilla.
+type NewDocument = Rc<dyn Fn(Option<&str>)>;
 
 pub struct ScribeWindow {
     pub window: adw::ApplicationWindow,
     load_file: Rc<dyn Fn(&Path)>,
 }
 
-/// Sustituye el home del usuario por `~` para que el subtítulo no ocupe media barra.
 fn shorten_home(path: &Path) -> String {
     let s = path.to_string_lossy().to_string();
     if let Some(home) = glib::home_dir().to_str() {
         if let Some(rest) = s.strip_prefix(home) {
-            return format!("~{}", rest);
+            return format!("~{rest}");
         }
     }
     s
 }
 
-/// Reconstruye el índice, saltándose las cabeceras que estén dentro de un bloque de código.
 fn rebuild_toc(list: &gtk4::ListBox, lines_out: &Rc<RefCell<Vec<i32>>>, text: &str) {
     while let Some(child) = list.first_child() {
         list.remove(&child);
@@ -139,11 +50,11 @@ fn rebuild_toc(list: &gtk4::ListBox, lines_out: &Rc<RefCell<Vec<i32>>>, text: &s
             continue;
         }
         let level = trimmed.chars().take_while(|c| *c == '#').count();
-        if level == 0 || level > 6 {
+        if level == 0 || level > 6 || !trimmed[level..].starts_with(' ') {
             continue;
         }
         let rest = trimmed[level..].trim();
-        if rest.is_empty() || !trimmed[level..].starts_with(' ') {
+        if rest.is_empty() {
             continue;
         }
 
@@ -161,15 +72,14 @@ fn rebuild_toc(list: &gtk4::ListBox, lines_out: &Rc<RefCell<Vec<i32>>>, text: &s
         } else if level >= 3 {
             label.add_css_class("dim-label");
         }
-
-        let row = gtk4::ListBoxRow::builder()
-            .child(&label)
-            .activatable(true)
-            .build();
-        list.append(&row);
+        list.append(
+            &gtk4::ListBoxRow::builder()
+                .child(&label)
+                .activatable(true)
+                .build(),
+        );
         lines.push(idx as i32);
     }
-
     *lines_out.borrow_mut() = lines;
 }
 
@@ -181,7 +91,6 @@ impl ScribeWindow {
         let is_modified = Rc::new(Cell::new(false));
         let force_close = Rc::new(Cell::new(false));
         let alive = Rc::new(Cell::new(true));
-        let recents: Rc<RefCell<Vec<PathBuf>>> = Rc::new(RefCell::new(Vec::new()));
         let toc_lines: Rc<RefCell<Vec<i32>>> = Rc::new(RefCell::new(Vec::new()));
 
         let window = adw::ApplicationWindow::builder()
@@ -189,19 +98,15 @@ impl ScribeWindow {
             .default_width(settings.window_width())
             .default_height(settings.window_height())
             .build();
+        if settings.window_maximized() {
+            window.maximize();
+        }
 
-        // === EDITOR ===
         let editor = Rc::new(Editor::new());
-        editor.widget.set_hexpand(true);
-        editor.widget.set_vexpand(true);
-        editor.set_style(settings.font_size(), settings.line_spacing());
-
-        // === PREVIEW ===
         let preview = Rc::new(PreviewPanel::new());
-        preview.set_font_size(settings.font_size());
         let preview_visible = Rc::new(Cell::new(settings.show_preview()));
 
-        // === SIDEBAR ===
+        // ============================ BARRA LATERAL ============================
         let sidebar_header = adw::HeaderBar::builder()
             .title_widget(&adw::WindowTitle::new("Documentos", ""))
             .show_end_title_buttons(false)
@@ -210,63 +115,57 @@ impl ScribeWindow {
 
         let search_entry = gtk4::SearchEntry::builder()
             .placeholder_text("Filtrar recientes…")
-            .margin_top(12)
+            .margin_top(6)
             .margin_bottom(6)
             .margin_start(12)
             .margin_end(12)
             .build();
 
-        let notes_label = gtk4::Label::builder()
-            .label("Recientes")
-            .halign(gtk4::Align::Start)
-            .css_classes(vec!["heading".to_string(), "dim-label".to_string()])
-            .margin_start(12)
-            .margin_top(12)
-            .build();
-
-        let notes_list = gtk4::ListBox::builder()
+        let recents_list = gtk4::ListBox::builder()
             .selection_mode(gtk4::SelectionMode::None)
             .css_classes(vec!["navigation-sidebar".to_string()])
             .build();
-
-        let toc_label = gtk4::Label::builder()
-            .label("Contenido")
-            .halign(gtk4::Align::Start)
-            .css_classes(vec!["heading".to_string(), "dim-label".to_string()])
-            .margin_start(12)
-            .margin_top(12)
-            .build();
-
         let toc_list = gtk4::ListBox::builder()
             .selection_mode(gtk4::SelectionMode::None)
             .css_classes(vec!["navigation-sidebar".to_string()])
             .build();
 
+        let section = |text: &str| {
+            gtk4::Label::builder()
+                .label(text)
+                .halign(gtk4::Align::Start)
+                .css_classes(vec!["heading".to_string(), "dim-label".to_string()])
+                .margin_start(12)
+                .margin_top(12)
+                .margin_bottom(2)
+                .build()
+        };
+
         let sidebar_content = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
         sidebar_content.append(&search_entry);
-        sidebar_content.append(&notes_label);
-        sidebar_content.append(&notes_list);
-        sidebar_content.append(&toc_label);
+        sidebar_content.append(&section("Recientes"));
+        sidebar_content.append(&recents_list);
+        sidebar_content.append(&section("Contenido"));
         sidebar_content.append(&toc_list);
 
-        let sidebar_scrolled = gtk4::ScrolledWindow::builder()
-            .hscrollbar_policy(gtk4::PolicyType::Never)
-            .vexpand(true)
-            .child(&sidebar_content)
-            .build();
-
         let sidebar_box = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
-        sidebar_box.set_width_request(260);
+        sidebar_box.set_width_request(280);
         sidebar_box.add_css_class("sidebar");
         sidebar_box.append(&sidebar_header);
-        sidebar_box.append(&sidebar_scrolled);
+        sidebar_box.append(
+            &gtk4::ScrolledWindow::builder()
+                .hscrollbar_policy(gtk4::PolicyType::Never)
+                .vexpand(true)
+                .child(&sidebar_content)
+                .build(),
+        );
 
-        // === PANED ===
+        // ============================== CONTENIDO ==============================
         let paned = gtk4::Paned::builder()
             .orientation(gtk4::Orientation::Horizontal)
             .start_child(&editor.widget)
             .wide_handle(true)
-            .position(600)
+            .position(680)
             .hexpand(true)
             .vexpand(true)
             .shrink_start_child(false)
@@ -276,58 +175,47 @@ impl ScribeWindow {
             paned.set_end_child(Some(&preview.widget));
         }
 
-        // === HEADERBAR ===
+        // ============================== CABECERA ===============================
+        // Mismo reparto que GNOME Text Editor: abrir (con recientes) y nuevo a la
+        // izquierda, título al centro, menú principal a la derecha.
         let header = adw::HeaderBar::new();
 
-        let open_btn = gtk4::Button::builder()
-            .icon_name("document-open-symbolic")
-            .tooltip_text("Abrir (Ctrl+O)")
-            .action_name("win.open")
+        let recents_menu = gio::Menu::new();
+        let open_button = adw::SplitButton::builder()
+            .label("Abrir")
+            .tooltip_text("Abrir un documento (Ctrl+O)")
+            .menu_model(&recents_menu)
             .build();
-        header.pack_start(&open_btn);
+        open_button.set_action_name(Some("win.open"));
+        header.pack_start(&open_button);
 
-        let save_btn = gtk4::Button::builder()
-            .icon_name("document-save-symbolic")
-            .tooltip_text("Guardar (Ctrl+S)")
-            .action_name("win.save")
+        let templates_menu = gio::Menu::new();
+        let new_button = gtk4::MenuButton::builder()
+            .icon_name("document-new-symbolic")
+            .tooltip_text("Documento nuevo (Ctrl+N)")
+            .menu_model(&templates_menu)
             .build();
-        header.pack_start(&save_btn);
+        header.pack_start(&new_button);
 
         let title_widget = adw::WindowTitle::new("Sin título", "");
         header.set_title_widget(Some(&title_widget));
 
-        let menu_btn = gtk4::MenuButton::builder()
+        let menu_button = gtk4::MenuButton::builder()
             .icon_name("open-menu-symbolic")
             .primary(true)
             .tooltip_text("Menú principal")
             .build();
-        header.pack_end(&menu_btn);
+        header.pack_end(&menu_button);
 
-        let preview_btn = gtk4::ToggleButton::builder()
-            .icon_name("view-dual-symbolic")
-            .tooltip_text("Vista dividida (Ctrl+Shift+P)")
-            .active(preview_visible.get())
-            .build();
-        header.pack_end(&preview_btn);
-
-        // Estadísticas del documento, en un popover que se recalcula al abrirlo.
-        let stats_label = gtk4::Label::builder()
-            .halign(gtk4::Align::Start)
-            .margin_top(12)
-            .margin_bottom(12)
-            .margin_start(12)
-            .margin_end(12)
-            .build();
-        let stats_popover = gtk4::Popover::builder().child(&stats_label).build();
-        let stats_btn = gtk4::MenuButton::builder()
-            .icon_name("info-symbolic")
-            .tooltip_text("Estadísticas del documento")
-            .popover(&stats_popover)
-            .build();
-        header.pack_end(&stats_btn);
-
-        // === MENU ===
+        // ---- menú principal, con la fila de zoom como en las apps de GNOME ----
         let menu = gio::Menu::new();
+
+        let zoom_section = gio::Menu::new();
+        let zoom_item = gio::MenuItem::new(None, None);
+        zoom_item.set_attribute_value("custom", Some(&"zoom".to_variant()));
+        zoom_section.append_item(&zoom_item);
+        menu.append_section(None, &zoom_section);
+
         let file_section = gio::Menu::new();
         file_section.append(Some("Nueva ventana"), Some("app.new-window"));
         file_section.append(Some("Abrir…"), Some("win.open"));
@@ -338,31 +226,103 @@ impl ScribeWindow {
         let view_section = gio::Menu::new();
         view_section.append(Some("Barra lateral"), Some("win.toggle-sidebar"));
         view_section.append(Some("Vista dividida"), Some("win.toggle-preview"));
+        view_section.append(Some("Modo foco"), Some("win.focus-mode"));
+        view_section.append(Some("Máquina de escribir"), Some("win.typewriter-mode"));
         menu.append_section(None, &view_section);
 
         let app_section = gio::Menu::new();
         app_section.append(Some("Preferencias"), Some("win.preferences"));
         app_section.append(Some("Atajos de teclado"), Some("win.show-help-overlay"));
         app_section.append(Some("Acerca de Scribe"), Some("win.about"));
-        app_section.append(Some("Salir"), Some("app.quit"));
         menu.append_section(None, &app_section);
-        menu_btn.set_menu_model(Some(&menu));
 
-        // === CONTENT ===
-        // Barra de estado inferior, al estilo de GNOME Text Editor.
-        let status_words = gtk4::Label::builder()
-            .css_classes(vec!["caption".to_string(), "dim-label".to_string()])
-            .build();
-        let status_pos = gtk4::Label::builder()
-            .css_classes(vec!["caption".to_string(), "dim-label".to_string()])
-            .build();
-        let status_bar = gtk4::CenterBox::builder()
-            .css_classes(vec!["toolbar".to_string()])
+        let zoom_box = gtk4::Box::builder()
+            .orientation(gtk4::Orientation::Horizontal)
+            .css_classes(vec!["linked".to_string()])
+            .margin_top(6)
+            .margin_bottom(6)
             .margin_start(12)
             .margin_end(12)
             .build();
-        status_bar.set_start_widget(Some(&status_words));
-        status_bar.set_end_widget(Some(&status_pos));
+        let zoom_out = gtk4::Button::builder()
+            .icon_name("zoom-out-symbolic")
+            .action_name("win.zoom-out")
+            .tooltip_text("Reducir")
+            .build();
+        let zoom_label = gtk4::Button::builder()
+            .action_name("win.zoom-reset")
+            .hexpand(true)
+            .tooltip_text("Restablecer")
+            .build();
+        let zoom_in = gtk4::Button::builder()
+            .icon_name("zoom-in-symbolic")
+            .action_name("win.zoom-in")
+            .tooltip_text("Ampliar")
+            .build();
+        zoom_box.append(&zoom_out);
+        zoom_box.append(&zoom_label);
+        zoom_box.append(&zoom_in);
+
+        let popover = gtk4::PopoverMenu::from_model(Some(&menu));
+        popover.add_child(&zoom_box, "zoom");
+        menu_button.set_popover(Some(&popover));
+
+        // ============================ BARRA DE ESTADO ==========================
+        let words_label = gtk4::Label::builder()
+            .css_classes(vec!["caption".to_string(), "dim-label".to_string()])
+            .build();
+
+        let goto_spin = gtk4::SpinButton::with_range(1.0, 1.0, 1.0);
+        goto_spin.set_numeric(true);
+        let goto_button = gtk4::Button::builder()
+            .label("Ir")
+            .css_classes(vec!["suggested-action".to_string()])
+            .build();
+        let goto_box = gtk4::Box::builder()
+            .orientation(gtk4::Orientation::Horizontal)
+            .spacing(6)
+            .margin_top(10)
+            .margin_bottom(10)
+            .margin_start(10)
+            .margin_end(10)
+            .build();
+        goto_box.append(&gtk4::Label::new(Some("Línea")));
+        goto_box.append(&goto_spin);
+        goto_box.append(&goto_button);
+        let goto_popover = gtk4::Popover::builder().child(&goto_box).build();
+
+        let position_button = gtk4::MenuButton::builder()
+            .label("Ln 1, Col 1")
+            .tooltip_text("Ir a la línea")
+            .css_classes(vec!["flat".to_string()])
+            .popover(&goto_popover)
+            .build();
+
+        let props_label = gtk4::Label::builder()
+            .halign(gtk4::Align::Start)
+            .margin_top(12)
+            .margin_bottom(12)
+            .margin_start(12)
+            .margin_end(12)
+            .build();
+        let props_button = gtk4::MenuButton::builder()
+            .label("Markdown")
+            .tooltip_text("Propiedades del documento")
+            .css_classes(vec!["flat".to_string()])
+            .popover(&gtk4::Popover::builder().child(&props_label).build())
+            .build();
+
+        let status_end = gtk4::Box::new(gtk4::Orientation::Horizontal, 0);
+        status_end.append(&position_button);
+        status_end.append(&props_button);
+
+        let status_bar = gtk4::CenterBox::builder()
+            .css_classes(vec!["toolbar".to_string()])
+            .margin_start(12)
+            .margin_end(6)
+            .build();
+        status_bar.set_start_widget(Some(&words_label));
+        status_bar.set_end_widget(Some(&status_end));
 
         let toolbar_view = adw::ToolbarView::new();
         toolbar_view.add_top_bar(&header);
@@ -372,30 +332,24 @@ impl ScribeWindow {
         let toasts = adw::ToastOverlay::new();
         toasts.set_child(Some(&toolbar_view));
 
-        let overlay_split = adw::OverlaySplitView::builder()
+        let split_view = adw::OverlaySplitView::builder()
             .sidebar(&sidebar_box)
             .content(&toasts)
             .show_sidebar(settings.show_sidebar())
             .enable_hide_gesture(true)
             .enable_show_gesture(true)
             .build();
+        window.set_content(Some(&split_view));
 
-        window.set_content(Some(&overlay_split));
-
-        // Ventana de atajos -> registra automáticamente win.show-help-overlay.
         let builder = gtk4::Builder::from_string(SHORTCUTS_UI);
         if let Some(help) = builder.object::<gtk4::ShortcutsWindow>("help_overlay") {
             window.set_help_overlay(Some(&help));
         }
 
-        // ---------------------------------------------------------------
-        // Helpers compartidos
-        // ---------------------------------------------------------------
+        // ============================== AYUDANTES ==============================
         let toast = {
             let toasts = toasts.clone();
-            Rc::new(move |msg: &str| {
-                toasts.add_toast(adw::Toast::new(msg));
-            })
+            Rc::new(move |msg: &str| toasts.add_toast(adw::Toast::new(msg)))
         };
 
         let update_title: Rc<dyn Fn()> = {
@@ -403,6 +357,7 @@ impl ScribeWindow {
             let is_modified = is_modified.clone();
             let title_widget = title_widget.clone();
             let window = window.clone();
+            let editor = editor.clone();
             Rc::new(move || {
                 let file = current_file.borrow();
                 let (name, subtitle) = match file.as_ref() {
@@ -413,7 +368,13 @@ impl ScribeWindow {
                             .to_string(),
                         p.parent().map(shorten_home).unwrap_or_default(),
                     ),
-                    None => ("Sin título".to_string(), "No guardado".to_string()),
+                    // Sin fichero, el borrador se identifica por su primera
+                    // cabecera, que es lo que el usuario tiene en la cabeza.
+                    None => (
+                        templates::title_from(&editor.text())
+                            .unwrap_or_else(|| "Sin título".to_string()),
+                        "Borrador".to_string(),
+                    ),
                 };
                 let dot = if is_modified.get() { "• " } else { "" };
                 title_widget.set_title(&format!("{dot}{name}"));
@@ -424,32 +385,39 @@ impl ScribeWindow {
 
         let update_status: Rc<dyn Fn()> = {
             let editor = editor.clone();
-            let status_words = status_words.clone();
-            let status_pos = status_pos.clone();
+            let words_label = words_label.clone();
+            let position_button = position_button.clone();
+            let props_label = props_label.clone();
+            let goto_spin = goto_spin.clone();
             Rc::new(move || {
                 let text = editor.text();
                 let words = text.split_whitespace().count();
                 let chars = text.chars().count();
-                status_words.set_label(&format!("{words} palabras · {chars} caracteres"));
+                let lines = editor.line_count();
+                words_label.set_label(&format!("{words} palabras"));
                 let (line, column) = editor.cursor_position();
-                status_pos.set_label(&format!("Ln {line}, Col {column}"));
+                position_button.set_label(&format!("Ln {line}, Col {column}"));
+                goto_spin.set_range(1.0, lines.max(1) as f64);
+                goto_spin.set_value(line as f64);
+                let minutes = (words as f64 / 200.0).ceil().max(1.0) as usize;
+                props_label.set_label(&format!(
+                    "Palabras: {words}\nCaracteres: {chars}\nLíneas: {lines}\nLectura: ~{minutes} min"
+                ));
             })
         };
-        {
-            let update_status = update_status.clone();
-            editor.connect_cursor_moved(move || update_status());
-        }
 
         let refresh_recents: Rc<dyn Fn(&str)> = {
             let settings = settings.clone();
-            let notes_list = notes_list.clone();
-            let recents = recents.clone();
+            let recents_list = recents_list.clone();
+            let recents_menu = recents_menu.clone();
             Rc::new(move |filter: &str| {
-                while let Some(child) = notes_list.first_child() {
-                    notes_list.remove(&child);
+                while let Some(child) = recents_list.first_child() {
+                    recents_list.remove(&child);
                 }
+                recents_menu.remove_all();
+
                 let needle = filter.to_lowercase();
-                let mut paths = Vec::new();
+                let mut shown = 0;
                 for entry in settings.recent_files() {
                     let path = PathBuf::from(&entry);
                     let name = path
@@ -465,14 +433,25 @@ impl ScribeWindow {
                         .subtitle(path.parent().map(shorten_home).unwrap_or_default())
                         .activatable(true)
                         .build();
+                    row.set_action_name(Some("win.open-recent"));
+                    row.set_action_target_value(Some(&entry.to_variant()));
                     if !path.exists() {
                         row.set_subtitle("No encontrado");
                         row.set_sensitive(false);
                     }
-                    notes_list.append(&row);
-                    paths.push(path);
+                    recents_list.append(&row);
+
+                    if shown < 10 && path.exists() {
+                        let item = gio::MenuItem::new(Some(&name), None);
+                        item.set_action_and_target_value(
+                            Some("win.open-recent"),
+                            Some(&entry.to_variant()),
+                        );
+                        recents_menu.append_item(&item);
+                    }
+                    shown += 1;
                 }
-                if paths.is_empty() {
+                if shown == 0 {
                     let row = adw::ActionRow::builder()
                         .title(if needle.is_empty() {
                             "Sin documentos recientes"
@@ -481,12 +460,36 @@ impl ScribeWindow {
                         })
                         .build();
                     row.set_sensitive(false);
-                    notes_list.append(&row);
+                    recents_list.append(&row);
                 }
-                *recents.borrow_mut() = paths;
             })
         };
         refresh_recents("");
+
+        let refresh_templates: Rc<dyn Fn()> = {
+            let templates_menu = templates_menu.clone();
+            Rc::new(move || {
+                templates_menu.remove_all();
+                let blank = gio::Menu::new();
+                blank.append(Some("Documento en blanco"), Some("win.new-document"));
+                templates_menu.append_section(None, &blank);
+
+                let list = templates::list();
+                if !list.is_empty() {
+                    let section = gio::Menu::new();
+                    for template in list {
+                        let item = gio::MenuItem::new(Some(&template.name), None);
+                        item.set_action_and_target_value(
+                            Some("win.new-from-template"),
+                            Some(&template.name.to_variant()),
+                        );
+                        section.append_item(&item);
+                    }
+                    templates_menu.append_section(Some("Plantillas"), &section);
+                }
+            })
+        };
+        refresh_templates();
 
         let load_file: Rc<dyn Fn(&Path)> = {
             let editor = editor.clone();
@@ -494,6 +497,7 @@ impl ScribeWindow {
             let is_modified = is_modified.clone();
             let settings = settings.clone();
             let update_title = update_title.clone();
+            let update_status = update_status.clone();
             let refresh_recents = refresh_recents.clone();
             let toast = toast.clone();
             Rc::new(move |path: &Path| match std::fs::read_to_string(path) {
@@ -504,24 +508,94 @@ impl ScribeWindow {
                     settings.push_recent_file(&path.to_string_lossy());
                     refresh_recents("");
                     update_title();
+                    update_status();
                 }
                 Err(e) => toast(&format!("No se pudo abrir: {e}")),
             })
         };
 
-        // ---------------------------------------------------------------
-        // Acciones
-        // ---------------------------------------------------------------
+        let new_document: NewDocument = {
+            let editor = editor.clone();
+            let current_file = current_file.clone();
+            let is_modified = is_modified.clone();
+            let update_title = update_title.clone();
+            let update_status = update_status.clone();
+            Rc::new(move |template_name: Option<&str>| {
+                let body = template_name
+                    .and_then(templates::find)
+                    .and_then(|t| t.body())
+                    .map(|b| templates::render(&b, "Sin título"))
+                    .unwrap_or_default();
+                editor.set_text(&body);
+                *current_file.borrow_mut() = None;
+                is_modified.set(false);
+                update_title();
+                update_status();
+            })
+        };
+
+        // ============================== ACCIONES ===============================
         let action_open = gio::SimpleAction::new("open", None);
         let action_save = gio::SimpleAction::new("save", None);
         let action_save_as = gio::SimpleAction::new("save-as", None);
-        let action_toggle_sidebar = gio::SimpleAction::new("toggle-sidebar", None);
-        let action_toggle_preview = gio::SimpleAction::new("toggle-preview", None);
         let action_preferences = gio::SimpleAction::new("preferences", None);
         let action_about = gio::SimpleAction::new("about", None);
+        let action_new_document = gio::SimpleAction::new("new-document", None);
+        let action_open_recent =
+            gio::SimpleAction::new("open-recent", Some(glib::VariantTy::STRING));
+        let action_new_template =
+            gio::SimpleAction::new("new-from-template", Some(glib::VariantTy::STRING));
+        let action_zoom_in = gio::SimpleAction::new("zoom-in", None);
+        let action_zoom_out = gio::SimpleAction::new("zoom-out", None);
+        let action_zoom_reset = gio::SimpleAction::new("zoom-reset", None);
         let action_bold = gio::SimpleAction::new("bold", None);
         let action_italic = gio::SimpleAction::new("italic", None);
         let action_code = gio::SimpleAction::new("code", None);
+
+        // Las alternancias son con estado, para que el menú muestre la marca.
+        let action_sidebar = gio::SimpleAction::new_stateful(
+            "toggle-sidebar",
+            None,
+            &settings.show_sidebar().to_variant(),
+        );
+        let action_preview = gio::SimpleAction::new_stateful(
+            "toggle-preview",
+            None,
+            &settings.show_preview().to_variant(),
+        );
+        let action_focus = gio::SimpleAction::new_stateful(
+            "focus-mode",
+            None,
+            &settings.focus_mode().to_variant(),
+        );
+        let action_typewriter = gio::SimpleAction::new_stateful(
+            "typewriter-mode",
+            None,
+            &settings.typewriter_mode().to_variant(),
+        );
+
+        for a in [
+            &action_open,
+            &action_save,
+            &action_save_as,
+            &action_preferences,
+            &action_about,
+            &action_new_document,
+            &action_zoom_in,
+            &action_zoom_out,
+            &action_zoom_reset,
+            &action_bold,
+            &action_italic,
+            &action_code,
+        ] {
+            window.add_action(a);
+        }
+        window.add_action(&action_open_recent);
+        window.add_action(&action_new_template);
+        window.add_action(&action_sidebar);
+        window.add_action(&action_preview);
+        window.add_action(&action_focus);
+        window.add_action(&action_typewriter);
 
         for (action, marker) in [
             (&action_bold, "**"),
@@ -532,22 +606,105 @@ impl ScribeWindow {
             action.connect_activate(move |_, _| editor.wrap_selection(marker));
         }
 
-        for a in [
-            &action_open,
-            &action_save,
-            &action_save_as,
-            &action_toggle_sidebar,
-            &action_toggle_preview,
-            &action_preferences,
-            &action_about,
-            &action_bold,
-            &action_italic,
-            &action_code,
-        ] {
-            window.add_action(a);
+        // ---- aplicar preferencias ----
+        let apply_settings: Rc<dyn Fn()> = {
+            let settings = settings.clone();
+            let editor = editor.clone();
+            let preview = preview.clone();
+            let zoom_label = zoom_label.clone();
+            let refresh_recents = refresh_recents.clone();
+            let refresh_templates = refresh_templates.clone();
+            Rc::new(move || {
+                adw::StyleManager::default().set_color_scheme(
+                    match settings.color_scheme_index() {
+                        1 => adw::ColorScheme::ForceLight,
+                        2 => adw::ColorScheme::ForceDark,
+                        _ => adw::ColorScheme::Default,
+                    },
+                );
+                let size = settings.font_size();
+                editor.set_font(settings.font_family(), size, settings.line_spacing());
+                editor.set_column_width(settings.column_width());
+                editor.set_markup_visibility(settings.markup_visibility());
+                editor.set_focus_mode(settings.focus_mode());
+                editor.set_typewriter_mode(settings.typewriter_mode());
+                editor.set_continue_lists(settings.continue_lists());
+                editor.set_tab_width(settings.tab_width());
+                preview.set_font_size(size);
+                zoom_label.set_label(&format!("{}px", size));
+                refresh_recents("");
+                refresh_templates();
+            })
+        };
+        apply_settings();
+
+        {
+            let window_clone = window.clone();
+            let settings = settings.clone();
+            let apply_settings = apply_settings.clone();
+            let action_focus = action_focus.clone();
+            let action_typewriter = action_typewriter.clone();
+            action_preferences.connect_activate(move |_, _| {
+                let action_focus = action_focus.clone();
+                let action_typewriter = action_typewriter.clone();
+                let settings_inner = settings.clone();
+                let apply_inner = apply_settings.clone();
+                // Las preferencias y el menú comparten estado: hay que
+                // sincronizar las alternancias en los dos sentidos.
+                let sync: Rc<dyn Fn()> = Rc::new(move || {
+                    action_focus.set_state(&settings_inner.focus_mode().to_variant());
+                    action_typewriter.set_state(&settings_inner.typewriter_mode().to_variant());
+                    apply_inner();
+                });
+                preferences::present(&window_clone, &settings, sync);
+            });
         }
 
-        // --- Abrir ---
+        // ---- zoom ----
+        for (action, delta) in [(&action_zoom_in, 1i32), (&action_zoom_out, -1)] {
+            let settings = settings.clone();
+            let apply_settings = apply_settings.clone();
+            action.connect_activate(move |_, _| {
+                settings.set_font_size((settings.font_size() + delta).clamp(9, 40));
+                apply_settings();
+            });
+        }
+        {
+            let settings = settings.clone();
+            let apply_settings = apply_settings.clone();
+            action_zoom_reset.connect_activate(move |_, _| {
+                settings.set_font_size(16);
+                apply_settings();
+            });
+        }
+
+        // ---- documentos nuevos ----
+        {
+            let new_document = new_document.clone();
+            let settings = settings.clone();
+            action_new_document.connect_activate(move |_, _| {
+                let name = settings.default_template();
+                new_document(if name.is_empty() { None } else { Some(&name) });
+            });
+        }
+        {
+            let new_document = new_document.clone();
+            action_new_template.connect_activate(move |_, param| {
+                if let Some(name) = param.and_then(|p| p.str()) {
+                    new_document(Some(name));
+                }
+            });
+        }
+        {
+            let load_file = load_file.clone();
+            action_open_recent.connect_activate(move |_, param| {
+                if let Some(path) = param.and_then(|p| p.str()) {
+                    load_file(Path::new(path));
+                }
+            });
+        }
+
+        // ---- abrir / guardar ----
         {
             let window = window.clone();
             let file_manager = file_manager.clone();
@@ -556,6 +713,7 @@ impl ScribeWindow {
             let is_modified = is_modified.clone();
             let settings = settings.clone();
             let update_title = update_title.clone();
+            let update_status = update_status.clone();
             let refresh_recents = refresh_recents.clone();
             let toast = toast.clone();
             action_open.connect_activate(move |_, _| {
@@ -564,6 +722,7 @@ impl ScribeWindow {
                 let is_modified = is_modified.clone();
                 let settings = settings.clone();
                 let update_title = update_title.clone();
+                let update_status = update_status.clone();
                 let refresh_recents = refresh_recents.clone();
                 let toast = toast.clone();
                 file_manager.open(&window, move |outcome| match outcome {
@@ -574,6 +733,7 @@ impl ScribeWindow {
                         settings.push_recent_file(&path.to_string_lossy());
                         refresh_recents("");
                         update_title();
+                        update_status();
                     }
                     OpenOutcome::Error(e) => toast(&e),
                     OpenOutcome::Cancelled => {}
@@ -581,7 +741,6 @@ impl ScribeWindow {
             });
         }
 
-        // --- Guardar / Guardar como ---
         let make_save = |force_dialog: bool| {
             let window = window.clone();
             let file_manager = file_manager.clone();
@@ -627,7 +786,75 @@ impl ScribeWindow {
         action_save.connect_activate(make_save(false));
         action_save_as.connect_activate(make_save(true));
 
-        // --- Editor cambiado: preview + índice con debounce ---
+        // ---- alternancias con estado ----
+        {
+            let split_view = split_view.clone();
+            let settings = settings.clone();
+            action_sidebar.connect_activate(move |action, _| {
+                let next = !split_view.shows_sidebar();
+                split_view.set_show_sidebar(next);
+                action.set_state(&next.to_variant());
+                settings.set_show_sidebar(next);
+            });
+        }
+        {
+            let paned = paned.clone();
+            let preview = preview.clone();
+            let preview_visible = preview_visible.clone();
+            let editor = editor.clone();
+            let settings = settings.clone();
+            action_preview.connect_activate(move |action, _| {
+                let next = !preview_visible.get();
+                preview_visible.set(next);
+                if next {
+                    preview.update(&editor.text());
+                    paned.set_end_child(Some(&preview.widget));
+                } else {
+                    paned.set_end_child(None::<&gtk4::Widget>);
+                }
+                action.set_state(&next.to_variant());
+                settings.set_show_preview(next);
+            });
+        }
+        for (action, is_focus) in [(&action_focus, true), (&action_typewriter, false)] {
+            let editor = editor.clone();
+            let settings = settings.clone();
+            action.connect_activate(move |action, _| {
+                let next = !action
+                    .state()
+                    .and_then(|s| s.get::<bool>())
+                    .unwrap_or(false);
+                action.set_state(&next.to_variant());
+                if is_focus {
+                    settings.set_focus_mode(next);
+                    editor.set_focus_mode(next);
+                } else {
+                    settings.set_typewriter_mode(next);
+                    editor.set_typewriter_mode(next);
+                }
+            });
+        }
+
+        // ---- acerca de ----
+        {
+            let window = window.clone();
+            action_about.connect_activate(move |_, _| {
+                adw::AboutWindow::builder()
+                    .transient_for(&window)
+                    .modal(true)
+                    .application_name("Scribe")
+                    .application_icon("app.scribe.Scribe")
+                    .developer_name("gnacho")
+                    .version(env!("CARGO_PKG_VERSION"))
+                    .website("https://github.com/gnacho/scribe")
+                    .issue_url("https://github.com/gnacho/scribe/issues")
+                    .license_type(gtk4::License::Agpl30)
+                    .build()
+                    .present();
+            });
+        }
+
+        // ============================== SEÑALES ================================
         {
             let preview = preview.clone();
             let preview_visible = preview_visible.clone();
@@ -638,15 +865,13 @@ impl ScribeWindow {
             let update_status = update_status.clone();
             let generation = Rc::new(Cell::new(0u64));
             editor.connect_changed(move |text| {
-                let was_modified = is_modified.replace(true);
-                if !was_modified {
+                if !is_modified.replace(true) {
                     update_title();
                 }
                 update_status();
-                // Antes se re-renderizaba el preview entero en cada pulsación.
-                let gen = generation.get().wrapping_add(1);
-                generation.set(gen);
 
+                let current = generation.get().wrapping_add(1);
+                generation.set(current);
                 let text = text.to_string();
                 let generation = generation.clone();
                 let preview = preview.clone();
@@ -654,7 +879,7 @@ impl ScribeWindow {
                 let toc_list = toc_list.clone();
                 let toc_lines = toc_lines.clone();
                 glib::timeout_add_local_once(Duration::from_millis(120), move || {
-                    if generation.get() != gen {
+                    if generation.get() != current {
                         return;
                     }
                     if preview_visible.get() {
@@ -664,65 +889,15 @@ impl ScribeWindow {
                 });
             });
         }
-
-        // --- Barra lateral ---
         {
-            let overlay_split = overlay_split.clone();
-            let settings = settings.clone();
-            action_toggle_sidebar.connect_activate(move |_, _| {
-                let next = !overlay_split.shows_sidebar();
-                overlay_split.set_show_sidebar(next);
-                settings.set_show_sidebar(next);
-            });
-        }
-
-        // --- Previsualización ---
-        // La acción sólo conmuta el botón; el botón es quien aplica el cambio.
-        // (Antes la acción leía el estado del botón, así que el atajo de teclado
-        //  no hacía nada: releía el mismo valor y lo volvía a aplicar.)
-        {
-            let preview_btn = preview_btn.clone();
-            action_toggle_preview.connect_activate(move |_, _| {
-                preview_btn.set_active(!preview_btn.is_active());
-            });
-        }
-        {
-            let paned = paned.clone();
-            let preview = preview.clone();
-            let preview_visible = preview_visible.clone();
-            let editor = editor.clone();
-            let settings = settings.clone();
-            preview_btn.connect_toggled(move |btn| {
-                let active = btn.is_active();
-                preview_visible.set(active);
-                if active {
-                    preview.update(&editor.text());
-                    paned.set_end_child(Some(&preview.widget));
-                } else {
-                    paned.set_end_child(None::<&gtk4::Widget>);
-                }
-                settings.set_show_preview(active);
-            });
-        }
-
-        // --- Recientes e índice clicables ---
-        {
-            let recents = recents.clone();
-            let load_file = load_file.clone();
-            notes_list.connect_row_activated(move |_, row| {
-                let idx = row.index() as usize;
-                let path = recents.borrow().get(idx).cloned();
-                if let Some(path) = path {
-                    load_file(&path);
-                }
-            });
+            let update_status = update_status.clone();
+            editor.connect_cursor_moved(move || update_status());
         }
         {
             let toc_lines = toc_lines.clone();
             let editor = editor.clone();
             toc_list.connect_row_activated(move |_, row| {
-                let idx = row.index() as usize;
-                let line = toc_lines.borrow().get(idx).copied();
+                let line = toc_lines.borrow().get(row.index() as usize).copied();
                 if let Some(line) = line {
                     editor.scroll_to_line(line);
                 }
@@ -730,143 +905,20 @@ impl ScribeWindow {
         }
         {
             let refresh_recents = refresh_recents.clone();
-            search_entry.connect_search_changed(move |entry| {
-                refresh_recents(entry.text().as_str());
-            });
+            search_entry
+                .connect_search_changed(move |entry| refresh_recents(entry.text().as_str()));
         }
-
-        // --- Estadísticas ---
         {
             let editor = editor.clone();
-            let stats_label = stats_label.clone();
-            stats_btn.connect_active_notify(move |btn| {
-                if !btn.is_active() {
-                    return;
-                }
-                let text = editor.text();
-                let words = text.split_whitespace().count();
-                let chars = text.chars().count();
-                let lines = text.lines().count();
-                // ~200 palabras por minuto de lectura.
-                let minutes = (words as f64 / 200.0).ceil().max(1.0) as usize;
-                stats_label.set_label(&format!(
-                    "Palabras: {words}\nCaracteres: {chars}\nLíneas: {lines}\nLectura: ~{minutes} min"
-                ));
+            let goto_spin = goto_spin.clone();
+            let goto_popover = goto_popover.clone();
+            goto_button.connect_clicked(move |_| {
+                editor.go_to_line(goto_spin.value() as i32);
+                goto_popover.popdown();
             });
         }
 
-        // --- Preferencias (ahora sí escriben en GSettings) ---
-        {
-            let window = window.clone();
-            let settings = settings.clone();
-            let editor = editor.clone();
-            let preview = preview.clone();
-            action_preferences.connect_activate(move |_, _| {
-                let prefs = adw::PreferencesWindow::builder()
-                    .transient_for(&window)
-                    .modal(true)
-                    .title("Preferencias")
-                    .build();
-
-                let page = adw::PreferencesPage::builder()
-                    .title("General")
-                    .icon_name("preferences-system-symbolic")
-                    .build();
-                let group = adw::PreferencesGroup::builder().title("Editor").build();
-
-                let font_row = adw::SpinRow::builder()
-                    .title("Tamaño de fuente")
-                    .subtitle("Píxeles")
-                    .adjustment(&gtk4::Adjustment::new(
-                        settings.font_size() as f64,
-                        8.0,
-                        48.0,
-                        1.0,
-                        1.0,
-                        0.0,
-                    ))
-                    .build();
-                group.add(&font_row);
-
-                let spacing_row = adw::SpinRow::builder()
-                    .title("Interlineado")
-                    .adjustment(&gtk4::Adjustment::new(
-                        settings.line_spacing(),
-                        1.0,
-                        3.0,
-                        0.1,
-                        0.1,
-                        0.0,
-                    ))
-                    .digits(1)
-                    .build();
-                group.add(&spacing_row);
-
-                let autosave_row = adw::SwitchRow::builder()
-                    .title("Guardado automático")
-                    .subtitle("Cada 30 segundos, si el documento ya tiene ruta")
-                    .active(settings.autosave())
-                    .build();
-                group.add(&autosave_row);
-
-                let apply = {
-                    let settings = settings.clone();
-                    let editor = editor.clone();
-                    let preview = preview.clone();
-                    let font_row = font_row.clone();
-                    let spacing_row = spacing_row.clone();
-                    Rc::new(move || {
-                        let size = font_row.value() as i32;
-                        let spacing = spacing_row.value();
-                        settings.set_font_size(size);
-                        settings.set_line_spacing(spacing);
-                        editor.set_style(size, spacing);
-                        preview.set_font_size(size);
-                    })
-                };
-                {
-                    let apply = apply.clone();
-                    font_row.connect_value_notify(move |_| apply());
-                }
-                {
-                    let apply = apply.clone();
-                    spacing_row.connect_value_notify(move |_| apply());
-                }
-                {
-                    let settings = settings.clone();
-                    autosave_row.connect_active_notify(move |row| {
-                        settings.set_autosave(row.is_active());
-                    });
-                }
-
-                page.add(&group);
-                prefs.add(&page);
-                prefs.present();
-            });
-        }
-
-        // --- Acerca de ---
-        {
-            let window = window.clone();
-            action_about.connect_activate(move |_, _| {
-                let about = adw::AboutWindow::builder()
-                    .transient_for(&window)
-                    .modal(true)
-                    .application_name("Scribe")
-                    .application_icon("app.scribe.Scribe")
-                    .developer_name("gnacho")
-                    .version(env!("CARGO_PKG_VERSION"))
-                    .website("https://github.com/gnacho/scribe")
-                    .issue_url("https://github.com/gnacho/scribe/issues")
-                    // El proyecto es AGPL-3.0 (LICENSE y Cargo.toml); antes aquí
-                    // ponía GPL-3.0 y no coincidía.
-                    .license_type(gtk4::License::Agpl30)
-                    .build();
-                about.present();
-            });
-        }
-
-        // --- Autoguardado ---
+        // ---- autoguardado ----
         {
             let settings = settings.clone();
             let editor = editor.clone();
@@ -874,10 +926,16 @@ impl ScribeWindow {
             let is_modified = is_modified.clone();
             let update_title = update_title.clone();
             let alive = alive.clone();
-            glib::timeout_add_seconds_local(30, move || {
+            let elapsed = Cell::new(0i32);
+            glib::timeout_add_seconds_local(5, move || {
                 if !alive.get() {
                     return glib::ControlFlow::Break;
                 }
+                elapsed.set(elapsed.get() + 5);
+                if elapsed.get() < settings.autosave_interval() {
+                    return glib::ControlFlow::Continue;
+                }
+                elapsed.set(0);
                 if settings.autosave() && is_modified.get() {
                     let path = current_file.borrow().clone();
                     if let Some(path) = path {
@@ -891,7 +949,7 @@ impl ScribeWindow {
             });
         }
 
-        // --- Cierre: guardar tamaño y avisar de cambios sin guardar ---
+        // ---- cierre ----
         {
             let settings = settings.clone();
             let is_modified = is_modified.clone();
@@ -904,6 +962,7 @@ impl ScribeWindow {
                 let (w, h) = win.default_size();
                 settings.set_window_width(w);
                 settings.set_window_height(h);
+                settings.set_window_maximized(win.is_maximized());
 
                 if force_close.get() || !is_modified.get() {
                     alive.set(false);
@@ -937,21 +996,17 @@ impl ScribeWindow {
                         "save" => {
                             let path = current_file.borrow().clone();
                             match path {
-                                Some(p) => {
-                                    if std::fs::write(&p, editor.text()).is_ok() {
-                                        force_close.set(true);
-                                        win.close();
-                                    }
+                                Some(p) if std::fs::write(&p, editor.text()).is_ok() => {
+                                    force_close.set(true);
+                                    win.close();
                                 }
-                                // Sin ruta hace falta el diálogo de guardar,
-                                // que es asíncrono: se deja la ventana abierta.
+                                Some(_) => {}
                                 None => action_save_as.activate(None),
                             }
                         }
                         _ => {}
                     }
                 });
-
                 glib::Propagation::Stop
             });
         }


### PR DESCRIPTION
Closes #2

## What

Interface overhaul aligned with GNOME HIG and GNOME Text Editor patterns.

### Added
- **Preferences window** (`AdwPreferencesWindow`) with three pages: Appearance (color scheme, font family, size, line spacing, column width), Editor (markup visibility, continue lists, focus/typewriter mode, tab width, autosave + interval), and Templates
- **Templates** (`src/templates.rs`): `.md` files in `$XDG_DATA_HOME/scribe/templates`, seeded with four examples on first launch. Support `{{title}}`, `{{date}}`, `{{time}}`, `{{datetime}}`, `{{year}}`
- **Configurable markup visibility**: hidden always / reveal on cursor line / dim always
- **Focus mode** (Ctrl+Shift+F): dim everything except the current paragraph
- **Typewriter mode** (Ctrl+Shift+T): keep cursor vertically centered
- **List continuation**: pressing Enter continues numbered/bullet lists with auto-renumbering; auto-closes on empty item
- **Zoom** (Ctrl +/-/0) with controls in the main menu
- **Go to line** from the status bar
- **Extended markup**: setext headings, autolinks, footnotes, dimmed HTML blocks, tables in monospace. Tests: 13 → 16
- **Shortcuts window** externalized to `src/shortcuts.ui`

### Changed
- **Header bar** reorganized like GNOME Text Editor: `AdwSplitButton` for Open with recent files dropdown + new document button on the left, title centered, main menu on the right
- **Toggle actions** now stateful with menu checkmarks
- **GSettings schema** rewritten with enums and ranges
- **`settings.rs`** rewritten with typed enums (`MarkupVisibility`, `ColorScheme`, `FontFamily`)

### Fixed
- Restored `app.quit` and `app.new-window` — Ctrl+Q was broken and two menu entries were grayed out
- Restored `ApplicationFlags::HANDLES_OPEN`
- `GtkTextTag:letter-spacing` negative value crash on heading tags

## Verification
- `cargo build --release`: ✅
- `cargo test`: ✅ 16/16 passed