### PR TITLE
fix(tables): monospaced table content so the visual grid aligns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to Scribe will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.4] - 2026-08-22
+
+### Fixed
+
+- **Contenido de tablas vuelve a monoespaciada** para que la rejilla visual
+  cuadre. La rejilla (cabecera en negrita, separadores pintados, filete) se
+  apoya en el padding del fuente que produce `format_tables`; con fuente
+  proporcional las columnas no alineaban. El inline (negrita, código, color)
+  sigue aplicando: son atributos independientes de la familia. Si una tabla no
+  cuadra, Ctrl+Alt+T («Formatear tablas») la deja alineada.
+- **Test de render headless**: `tests/render_shot.rs` renderiza el editor a PNG
+  bajo xvfb (`SCRIBE_SHOTS_DIR` o temp dir) para verificar visualmente la vista
+  enriquecida sin abrir ventanas. El camino de salida original apuntaba al
+  sandbox del agente (`/mnt/agents/work/shots`) y fallaba en máquinas reales;
+  ahora es configurable por variable de entorno.
+
 ## [0.3.2] - 2026-08-22
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "scribe"
-version = "0.3.2"
+version = "0.3.4"
 dependencies = [
  "gdk4",
  "gio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scribe"
-version = "0.3.2"
+version = "0.3.4"
 edition = "2021"
 authors = ["gnacho"]
 description = "A native GNOME Markdown editor"

--- a/data/app.scribe.Scribe.metainfo.xml
+++ b/data/app.scribe.Scribe.metainfo.xml
@@ -25,6 +25,15 @@
   </developer>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="0.3.4" date="2026-08-22">
+      <description>
+        <p>El contenido de las tablas vuelve a monoespaciada para que la rejilla
+        visual cuadre con el padding del fuente; el inline sigue aplicando y
+        «Formatear tablas» (Ctrl+Alt+T) alinea las que no cuadren. Añade un
+        test de render headless (render_shot) que verifica la vista enriquecida
+        a PNG bajo xvfb.</p>
+      </description>
+    </release>
     <release version="0.3.2" date="2026-08-22">
       <description>
         <p>Corrige de raiz el aborto «byte index off the end of the line»: el

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -73,10 +73,11 @@ fn build_tags() -> gtk4::TextTagTable {
         let builder = gtk4::TextTag::builder().name(name);
         let tag = match name {
             "quote" => builder.style(pango::Style::Italic).build(),
-            // `table` no es monoespaciada: deja que el inline (strong, em,
-            // code, links) que genera `analyze` se interprete dentro de las
-            // celdas. El padding del fuente (véase `format_tables`) queda como
-            // separación natural; los pipes son marcas sustituidas.
+            // `table` vuelve a monoespaciada: la rejilla visual se apoya en el
+            // padding del fuente (véase `format_tables`) y eso exige ancho
+            // fijo. El inline (negrita, cursiva, color, código) son otros
+            // atributos y siguen aplicando encima sin problema.
+            "table" => builder.family("monospace").build(),
             "codeblock" => builder.family("monospace").scale(0.9).build(),
             // Sin sangría francesa: la viñeta se dibuja en el canalón, así que
             // todas las líneas del elemento arrancan en el mismo sitio.

--- a/tests/render_shot.rs
+++ b/tests/render_shot.rs
@@ -1,0 +1,118 @@
+//! Captura visual del editor: renderiza un documento de muestra a PNG para
+//! verificar la vista enriquecida (tablas, cajas de código, filetes de
+//! título, citas, listas, imágenes) sin abrir ventanas interactivas.
+//!
+//! Ejecutar: xvfb-run -a cargo test --test render_shot -- --ignored --nocapture
+//! Salida:   /mnt/agents/work/shots/*.png
+
+// Los módulos de la app se incluyen vía #[path] y el harness solo ejercita
+// parte de su API: el resto aparece como código muerto aunque la app sí lo
+// use (mismo criterio que tests/crash_stress.rs).
+#![allow(dead_code)]
+
+#[path = "../src/editor.rs"]
+mod editor;
+#[path = "../src/markdown_render.rs"]
+mod markdown_render;
+#[path = "../src/markdown_view.rs"]
+mod markdown_view;
+#[path = "../src/settings.rs"]
+mod settings;
+
+use editor::Editor;
+use gtk4::prelude::*;
+use std::time::{Duration, Instant};
+
+const DOC: &str = "\
+# Título principal
+
+## Sección con *énfasis* y `código`
+
+Texto normal con **negrita** y un [enlace](https://ejemplo.com).
+
+| Command    | Description                      | Precio |
+| ---------- | -------------------------------- | -----: |
+| git status | List all **new** or modified     |    $12 |
+| git diff   | Show file `differences`          |  $1600 |
+
+> Una cita con **marcado**
+> y dos líneas.
+
+- [x] Tarea hecha
+- [ ] Tarea pendiente
+- Elemento normal
+
+---
+
+```python
+def f():
+    return 1  # comentario
+```
+
+![gatito](test.png)
+";
+
+/// PNG de 64x48 generado con un codificador real (bicolor rojo/azul), para
+/// probar el pintado de imágenes locales.
+const TEST_PNG: &[u8] = &[
+    137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 64, 0, 0, 0, 48, 8, 2,
+    0, 0, 0, 46, 41, 235, 72, 0, 0, 0, 91, 73, 68, 65, 84, 120, 156, 237, 209, 65, 13, 192, 48, 16,
+    3, 193, 166, 184, 14, 73, 17, 7, 86, 65, 228, 49, 138, 180, 131, 192, 43, 175, 249, 246, 115,
+    179, 87, 15, 56, 85, 128, 86, 128, 86, 128, 86, 128, 86, 128, 86, 128, 86, 128, 86, 128, 86,
+    128, 86, 128, 86, 128, 182, 246, 140, 222, 112, 228, 250, 7, 10, 208, 10, 208, 10, 208, 10,
+    208, 10, 208, 10, 208, 10, 208, 10, 208, 10, 208, 10, 208, 10, 208, 126, 242, 14, 2, 253, 217,
+    136, 163, 109, 0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130,
+];
+
+fn pump(ctx: &gtk4::glib::MainContext, ms: u64) {
+    let t = Instant::now();
+    while t.elapsed() < Duration::from_millis(ms) {
+        while ctx.iteration(false) {}
+        std::thread::sleep(Duration::from_millis(4));
+    }
+}
+
+/// Renderiza el contenido de un widget a un PNG usando el renderer de la
+/// ventana ya realizada.
+fn shot(win: &gtk4::Window, path: &str) {
+    let w = win.width() as f64;
+    let h = win.height() as f64;
+    let paintable = gtk4::WidgetPaintable::new(Some(win));
+    let snapshot = gtk4::Snapshot::new();
+    paintable.snapshot(&snapshot, w, h);
+    let node = snapshot.to_node().expect("snapshot sin nodo raíz");
+    let renderer = win
+        .native()
+        .expect("sin native")
+        .renderer()
+        .expect("sin renderer");
+    let texture = renderer.render_texture(&node, None);
+    texture.save_to_png(path).expect("guardar png");
+}
+
+#[test]
+#[ignore = "requiere display: xvfb-run -a cargo test --test render_shot -- --ignored --nocapture"]
+fn captura_vista_enriquecida() {
+    gtk4::init().expect("GTK necesita un display; ejecuta bajo xvfb-run");
+    libadwaita::init().expect("libadwaita init");
+
+    let out = std::path::Path::new("/mnt/agents/work/shots");
+    std::fs::create_dir_all(out).expect("crear dir de salida");
+    std::fs::write(out.join("test.png"), TEST_PNG).expect("escribir imagen de prueba");
+
+    let editor = Editor::new();
+    editor.set_base_dir(Some(out.to_path_buf()));
+    let win = gtk4::Window::builder()
+        .default_width(760)
+        .default_height(1000)
+        .build();
+    win.set_child(Some(&editor.widget));
+    win.present();
+
+    let ctx = gtk4::glib::MainContext::default();
+    editor.set_text(DOC);
+    pump(&ctx, 600); // drena el debounce de decoración y el layout
+
+    shot(&win, &out.join("vista.png").display().to_string());
+    eprintln!("captura escrita en {}", out.join("vista.png").display());
+}

--- a/tests/render_shot.rs
+++ b/tests/render_shot.rs
@@ -96,8 +96,10 @@ fn captura_vista_enriquecida() {
     gtk4::init().expect("GTK necesita un display; ejecuta bajo xvfb-run");
     libadwaita::init().expect("libadwaita init");
 
-    let out = std::path::Path::new("/mnt/agents/work/shots");
-    std::fs::create_dir_all(out).expect("crear dir de salida");
+    let out = std::env::var("SCRIBE_SHOTS_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::env::temp_dir().join("scribe-shots"));
+    std::fs::create_dir_all(&out).expect("crear dir de salida");
     std::fs::write(out.join("test.png"), TEST_PNG).expect("escribir imagen de prueba");
 
     let editor = Editor::new();


### PR DESCRIPTION
The visual table grid (background box, bold header, painted separators, delimiter rule) is built on the font padding that `format_tables` produces. With a proportional body font the columns did not line up, so the cell content is monospaced again (inline styling such as bold and code still applies - it is independent of the font family). A table that still misaligns in the source can be realigned with `Ctrl+Alt+T` (Format tables).

Also adds `tests/render_shot.rs`: a headless render test that snapshots the editor to a PNG under xvfb for visual verification of the rich view. The original output path pointed at the agent sandbox (`/mnt/agents/work/shots`); it is now configurable via `SCRIBE_SHOTS_DIR` (fallback to the temp dir).

Verified: build --all-targets, 52/52 tests, clippy `-D warnings`, rustfmt, and `render_shot` under xvfb all pass.

Closes #7