### PR TITLE
feat: real multi-document tabs (AdwTabView) and continuous block boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to Scribe will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.6] - 2026-08-22
+
+### Added
+
+- **Pestañas reales multi-documento** (`AdwTabView` + `AdwTabBar`, estilo
+  gnome-text-editor). Cada documento tiene su editor, su undo, su estado de
+  guardado y su pestaña, con botón de cierre, reordenado por arrastre y
+  overflow. `Ctrl+N` nueva pestaña; `Ctrl+O`, recientes o `scribe fichero.md`
+  abren pestañas en la ventana activa; `Ctrl+W` cierra; `Ctrl+Tab` /
+  `Ctrl+Mayús+Tab` / `Ctrl+AvPág` / `Ctrl+RePág` navegan. Abrir un fichero ya
+  abierto enfoca su pestaña (dedupe por ruta canónica). Al cerrar una pestaña
+  con cambios: diálogo Guardar/Descartar/Cancelar; al cerrar la ventana con
+  varios modificados: diálogos secuenciales. Punto «•» en la pestaña modificada
+  + badge de atención en segundo plano; autoguardado por documento. La última
+  pestaña no se cierra (queda una en blanco).
+
+### Fixed
+
+- **Caja de fondo continua en bloques largos**: la caja se alargaba fuera de
+  pantalla para esconder las esquinas, y con origen muy negativo GSK no pintaba
+  nada (la caja desaparecía a mitad de un bloque de código de 120 líneas). Ahora
+  el rectángulo se limita a lo visible y las esquinas redondeadas solo se
+  dibujan en los bordes reales del bloque; la barra de cita usa el mismo
+  criterio.
+
 ## [0.3.4] - 2026-08-22
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "scribe"
-version = "0.3.4"
+version = "0.3.6"
 dependencies = [
  "gdk4",
  "gio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scribe"
-version = "0.3.4"
+version = "0.3.6"
 edition = "2021"
 authors = ["gnacho"]
 description = "A native GNOME Markdown editor"

--- a/data/app.scribe.Scribe.metainfo.xml
+++ b/data/app.scribe.Scribe.metainfo.xml
@@ -25,6 +25,15 @@
   </developer>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="0.3.6" date="2026-08-22">
+      <description>
+        <p>Pestañas reales multi-documento (AdwTabView/AdwTabBar): cada
+        documento tiene editor, undo y estado propios, con dedupe por ruta,
+        diálogos Guardar/Descartar/Cancelar y autoguardado por documento.
+        También se corrige la caja de fondo que desaparecía a mitad de los
+        bloques de código largos.</p>
+      </description>
+    </release>
     <release version="0.3.4" date="2026-08-22">
       <description>
         <p>El contenido de las tablas vuelve a monoespaciada para que la rejilla

--- a/examples/fence_probe.rs
+++ b/examples/fence_probe.rs
@@ -1,0 +1,28 @@
+//! Sonda de eventos de pulldown-cmark: vuelca el flujo de eventos de un
+//! fichero Markdown para diagnosticar cómo el parser interpreta vallas,
+//! tablas, imágenes, etc. Útil cuando el renderizado difiere de lo esperado.
+//!
+//! Uso: cargo run --example fence_probe -- ruta/al/fichero.md
+
+fn main() {
+    let text = std::fs::read_to_string(std::env::args().nth(1).unwrap()).unwrap();
+    let opts = pulldown_cmark::Options::ENABLE_TABLES
+        | pulldown_cmark::Options::ENABLE_FOOTNOTES
+        | pulldown_cmark::Options::ENABLE_STRIKETHROUGH
+        | pulldown_cmark::Options::ENABLE_TASKLISTS;
+    use pulldown_cmark::Event::*;
+    use pulldown_cmark::Tag;
+    let mut n = 0;
+    for ev in pulldown_cmark::Parser::new_ext(&text, opts) {
+        n += 1;
+        match ev {
+            Start(Tag::CodeBlock(k)) => println!("FENCE OPEN {k:?}"),
+            End(pulldown_cmark::TagEnd::CodeBlock) => println!("FENCE CLOSE"),
+            Start(Tag::Image { dest_url, .. }) => println!("IMAGE dest={dest_url}"),
+            Start(Tag::Heading { level, .. }) => println!("HEADING {level:?}"),
+            Start(Tag::Table(_)) => println!("TABLE"),
+            _ => {}
+        }
+    }
+    println!("TOTAL EVENTOS: {n}");
+}

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -15,6 +15,22 @@ type ChangedCallback = Rc<RefCell<Option<Box<dyn Fn(&str)>>>>;
 
 const MIN_MARGIN: i32 = 24;
 
+thread_local! {
+    /// Provider CSS único de la aplicación (D9): antes cada Editor instalaba
+    /// el suyo en el display y nunca lo retiraba, así que con pestañas se
+    /// acumulaban tantos providers como documentos. Ahora lo crea main una
+    /// sola vez y `set_font` lo recarga (el selector `textview.scribe-editor`
+    /// aplica a todos los editores, que comparten la misma fuente).
+    static APP_CSS: RefCell<Option<gtk4::CssProvider>> = const { RefCell::new(None) };
+}
+
+/// Instala el provider CSS de la aplicación. Lo llama main en el arranque;
+/// sin él (tests headless que crean un Editor suelto) `set_font` simplemente
+/// no inyecta CSS.
+pub fn install_app_css(provider: gtk4::CssProvider) {
+    APP_CSS.with(|slot| *slot.borrow_mut() = Some(provider));
+}
+
 /// Márgenes extra (izquierdo, derecho) de cada tag de bloque respecto al margen
 /// de la columna. El derecho importa en los bloques con caja dibujada: deja el
 /// texto por dentro del recuadro en vez de pegado al borde.
@@ -48,7 +64,6 @@ pub struct Editor {
     buffer: gtksourceview5::Buffer,
     tags: gtk4::TextTagTable,
     on_changed: ChangedCallback,
-    css: gtk4::CssProvider,
     last_line: Rc<Cell<i32>>,
     generation: Rc<Cell<u64>>,
     decoration: Rc<Cell<Decoration>>,
@@ -583,14 +598,7 @@ impl Editor {
             .child(&view)
             .build();
 
-        let css = gtk4::CssProvider::new();
-        if let Some(display) = gdk4::Display::default() {
-            gtk4::style_context_add_provider_for_display(
-                &display,
-                &css,
-                gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION,
-            );
-        }
+        // El CSS lo instala main a nivel de aplicación (véase APP_CSS).
 
         let dark = adw::StyleManager::default().is_dark();
         apply_scheme(&buffer, dark);
@@ -603,7 +611,6 @@ impl Editor {
             buffer,
             tags,
             on_changed: Rc::new(RefCell::new(None)),
-            css,
             last_line: Rc::new(Cell::new(-1)),
             generation: Rc::new(Cell::new(0)),
             decoration: Rc::new(Cell::new(Decoration::default())),
@@ -636,7 +643,11 @@ impl Editor {
         }
 
         // El StyleManager vive toda la aplicación: capturar los widgets en
-        // fuerte impediría liberar este editor al cerrar su ventana.
+        // fuerte impediría liberar este editor al cerrar su pestaña.
+        // R6 (aceptado): se registra un handler por editor y no se puede
+        // desconectar; como todas las capturas son débiles, los handlers de
+        // editores cerrados quedan inertes (un no-op por cambio de tema),
+        // no hay fuga de widgets.
         let tags = self.tags.downgrade();
         let buffer = self.buffer.downgrade();
         let view = self.view.downgrade();
@@ -859,10 +870,14 @@ impl Editor {
 
     pub fn set_font(&self, family: FontFamily, size: i32, line_spacing: f64) {
         let size = size.clamp(9, 40);
-        self.css.load_from_string(&format!(
-            "textview.scribe-editor {{ font-family: {}; font-size: {size}px; }}",
-            family.css_stack()
-        ));
+        APP_CSS.with(|slot| {
+            if let Some(css) = slot.borrow().as_ref() {
+                css.load_from_string(&format!(
+                    "textview.scribe-editor {{ font-family: {}; font-size: {size}px; }}",
+                    family.css_stack()
+                ));
+            }
+        });
         let extra = ((size as f64) * (line_spacing - 1.0)).round().max(0.0) as i32;
         self.view.set_pixels_above_lines(extra / 2);
         self.view.set_pixels_below_lines(extra / 2);

--- a/src/file_manager.rs
+++ b/src/file_manager.rs
@@ -74,7 +74,7 @@ impl FileManager {
         });
     }
 
-    pub fn save<F: Fn(Outcome) + 'static>(
+    pub fn save<F: FnOnce(Outcome) + 'static>(
         &self,
         parent: &impl IsA<gtk4::Window>,
         current: Option<&PathBuf>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use gtk4::prelude::*;
 use libadwaita as adw;
+use std::cell::RefCell;
 use std::rc::Rc;
 
 mod editor;
@@ -17,6 +18,15 @@ use window::ScribeWindow;
 
 const APP_ID: &str = "app.scribe.Scribe";
 
+// Registro de ventanas vivas: ScribeWindow es la ancla fuerte de sus
+// documentos (los closures de la ventana los capturan en Weak), así que hay
+// que retenerla mientras su ventana GTK exista. Las ventanas cerradas se
+// podan al destruirse (connect_destroy en build_window) y, por redundancia,
+// al consultar el registro.
+thread_local! {
+    static WINDOWS: RefCell<Vec<Rc<ScribeWindow>>> = const { RefCell::new(Vec::new()) };
+}
+
 fn main() -> glib::ExitCode {
     let app = adw::Application::builder()
         .application_id(APP_ID)
@@ -26,6 +36,19 @@ fn main() -> glib::ExitCode {
 
     app.connect_startup(|app| {
         templates::ensure_defaults();
+
+        // CSS a nivel de aplicación (D9): antes cada Editor instalaba su
+        // propio provider en el display y nunca lo retiraba; ahora hay uno
+        // solo, registrado una vez, que Editor::set_font recarga.
+        let css = gtk4::CssProvider::new();
+        if let Some(display) = gdk4::Display::default() {
+            gtk4::style_context_add_provider_for_display(
+                &display,
+                &css,
+                gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION,
+            );
+        }
+        editor::install_app_css(css);
 
         // Las acciones app.* deben existir: si no, las entradas del menú
         // salen grises y los aceleradores no hacen nada.
@@ -52,6 +75,9 @@ fn main() -> glib::ExitCode {
             ("win.open", &["<Ctrl>o"]),
             ("win.save", &["<Ctrl>s"]),
             ("win.save-as", &["<Ctrl><Shift>s"]),
+            ("win.close-tab", &["<Ctrl>w"]),
+            ("win.tab-next", &["<Ctrl>Tab", "<Ctrl>Page_Down"]),
+            ("win.tab-prev", &["<Ctrl><Shift>Tab", "<Ctrl>Page_Up"]),
             ("app.new-window", &["<Ctrl><Shift>n"]),
             ("app.quit", &["<Ctrl>q"]),
             ("win.bold", &["<Ctrl>b"]),
@@ -75,22 +101,56 @@ fn main() -> glib::ExitCode {
         }
     });
 
-    app.connect_activate(|app| build_window(app).present());
+    app.connect_activate(|app| {
+        build_window(app).present();
+    });
 
     app.connect_open(|app, files, _hint| {
+        // Los ficheros se abren como pestañas en la ventana activa; si no
+        // hay ninguna, se crea una.
+        let win = active_or_new_window(app);
         for file in files {
-            let win = build_window(app);
             if let Some(path) = file.path() {
                 win.open_path(&path);
             }
-            win.present();
         }
+        win.present();
     });
 
     app.run()
 }
 
-fn build_window(app: &adw::Application) -> ScribeWindow {
+fn build_window(app: &adw::Application) -> Rc<ScribeWindow> {
     let settings = Rc::new(AppSettings::new());
-    ScribeWindow::new(app, &settings)
+    let win = Rc::new(ScribeWindow::new(app, &settings));
+    WINDOWS.with(|list| list.borrow_mut().push(win.clone()));
+    // Poda estructural (revision): al destruirse la ventana GTK sale del
+    // registro. Antes solo se podaba al consultarlo (connect_open) y la
+    // memoria de las ventanas cerradas se acumulaba toda la sesion. El
+    // handler no captura nada: usar `dead` evita un autociclo.
+    win.window.connect_destroy(|dead| {
+        WINDOWS.with(|list| {
+            list.borrow_mut().retain(|w| {
+                w.window.upcast_ref::<gtk4::Window>() != dead.upcast_ref::<gtk4::Window>()
+            });
+        });
+    });
+    win
+}
+
+/// La ventana activa de Scribe, o una nueva si no hay ninguna. Poda del
+/// registro las ventanas que la aplicación ya ha olvidado (cerradas).
+fn active_or_new_window(app: &adw::Application) -> Rc<ScribeWindow> {
+    let found = WINDOWS.with(|list| {
+        let open = app.windows();
+        list.borrow_mut()
+            .retain(|w| open.contains(w.window.upcast_ref::<gtk4::Window>()));
+        app.active_window().and_then(|active| {
+            list.borrow()
+                .iter()
+                .find(|w| w.window.upcast_ref::<gtk4::Window>() == &active)
+                .cloned()
+        })
+    });
+    found.unwrap_or_else(|| build_window(app))
 }

--- a/src/markdown_view.rs
+++ b/src/markdown_view.rs
@@ -78,10 +78,6 @@ const QUOTE_BAR_OFFSET: f32 = 20.0;
 const RULE_THICKNESS: f32 = 1.0;
 /// Grosor de los separadores verticales de las tablas.
 const CELL_SEPARATOR_THICKNESS: f32 = 1.0;
-/// Cuanto se alarga fuera de la pantalla la caja de un bloque que empieza o
-/// acaba mas alla de lo visible, para que sus esquinas redondeadas no aparezcan
-/// cortadas a mitad del bloque.
-const BLOCK_OVERSHOOT: f32 = 4000.0;
 /// Alto del hueco que el tag `imagegap` reserva bajo la línea de una imagen.
 const IMAGE_GAP_HEIGHT: f32 = crate::markdown_render::IMAGE_GAP_HEIGHT as f32;
 /// Alto máximo de la imagen pintada en ese hueco (se escala manteniendo ratio).
@@ -207,7 +203,12 @@ mod imp {
                 // la maquetacion de miles de lineas en mitad del dibujado, y
                 // eso deja la vista en un estado incoherente: gtksourceview
                 // aborta despues con «byte index off the end of the line».
-                let anchor_top = first.max(first_visible - 1);
+                //
+                // El rect se LIMITA al rango visible (mas una linea de margen):
+                // un fill uniforme no necesita cubrir el bloque entero, y los
+                // rects enormes o con origen negativo rompen el clip redondeado
+                // de GSK (la caja desaparecia en medio de bloques largos).
+                let anchor_top = first.max(first_visible - 1).max(0);
                 let anchor_bottom = last.min(last_visible + 1);
                 let Some((anchor_y, _)) = self.line_extent(anchor_top) else {
                     continue;
@@ -215,14 +216,22 @@ mod imp {
                 let Some((bottom_y, bottom_h)) = self.line_extent(anchor_bottom) else {
                     continue;
                 };
-                let mut top = anchor_y;
-                let mut bottom = bottom_y + bottom_h;
-                if first < anchor_top {
-                    top -= BLOCK_OVERSHOOT;
-                }
-                if last > anchor_bottom {
-                    bottom += BLOCK_OVERSHOOT;
-                }
+                let top = anchor_y;
+                let bottom = bottom_y + bottom_h;
+                // Esquinas redondeadas solo en los bordes reales del bloque; si
+                // el bloque sigue fuera de pantalla, el borde visible va recto.
+                let corners = |radius: f32| {
+                    let corner = |visible_edge: bool| {
+                        let r = if visible_edge { radius } else { 0.0 };
+                        graphene::Size::new(r, r)
+                    };
+                    [
+                        corner(first == anchor_top),   // sup-izq
+                        corner(first == anchor_top),   // sup-dcha
+                        corner(last == anchor_bottom), // inf-dcha
+                        corner(last == anchor_bottom), // inf-izq
+                    ]
+                };
 
                 match ornament {
                     Ornament::CodeBlock { .. } | Ornament::Table { .. } => {
@@ -237,7 +246,8 @@ mod imp {
                             (right - left - BLOCK_PADDING * 2.0).max(0.0),
                             (bottom - top).max(0.0),
                         );
-                        let rounded = gsk::RoundedRect::from_rect(rect, BLOCK_RADIUS);
+                        let [tl, tr, br, bl] = corners(BLOCK_RADIUS);
+                        let rounded = gsk::RoundedRect::new(rect, tl, tr, br, bl);
                         snapshot.push_rounded_clip(&rounded);
                         snapshot.append_color(&fill, &rect);
                         snapshot.pop();
@@ -251,7 +261,8 @@ mod imp {
                             .unwrap_or(left + BLOCK_PADDING);
                         let rect =
                             graphene::Rect::new(x, top, QUOTE_BAR_WIDTH, (bottom - top).max(0.0));
-                        let rounded = gsk::RoundedRect::from_rect(rect, QUOTE_BAR_WIDTH / 2.0);
+                        let [tl, tr, br, bl] = corners(QUOTE_BAR_WIDTH / 2.0);
+                        let rounded = gsk::RoundedRect::new(rect, tl, tr, br, bl);
                         snapshot.push_rounded_clip(&rounded);
                         snapshot.append_color(&palette.quote, &rect);
                         snapshot.pop();

--- a/src/shortcuts.ui
+++ b/src/shortcuts.ui
@@ -49,6 +49,35 @@
         </child>
         <child>
           <object class="GtkShortcutsGroup">
+            <property name="title">Pestañas</property>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title">Cerrar pestaña</property>
+                <property name="accelerator">&lt;Control&gt;w</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title">Pestaña siguiente</property>
+                <property name="accelerator">&lt;Control&gt;Tab</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title">Pestaña anterior</property>
+                <property name="accelerator">&lt;Control&gt;&lt;Shift&gt;Tab</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title">Cambiar de pestaña</property>
+                <property name="accelerator">&lt;Control&gt;Page_Down &lt;Control&gt;Page_Up</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkShortcutsGroup">
             <property name="title">Formato</property>
             <child>
               <object class="GtkShortcutsShortcut">

--- a/src/window.rs
+++ b/src/window.rs
@@ -18,9 +18,49 @@ const SHORTCUTS_UI: &str = include_str!("shortcuts.ui");
 /// Crea un documento nuevo, opcionalmente a partir de una plantilla.
 type NewDocument = Rc<dyn Fn(Option<&str>)>;
 
+/// Factoría de documentos: texto inicial y fichero asociado (si lo hay).
+/// Devuelve el documento creado, ya insertado en el TabView y seleccionado.
+type CreateDocument = Rc<dyn Fn(String, Option<PathBuf>) -> Rc<Document>>;
+
+/// Un documento abierto: su editor, su estado de guardado y su pestaña.
+/// La ventana guarda `RefCell<Vec<Rc<Document>>>` y localiza cada documento
+/// por el puntero de su `page`.
+struct Document {
+    editor: Rc<Editor>,
+    current_file: RefCell<Option<PathBuf>>,
+    is_modified: Cell<bool>,
+    /// Segundos acumulados hacia el próximo autoguardado (D4: por documento).
+    autosave_elapsed: Cell<i32>,
+    /// true tras un fallo de autoguardado ya notificado (un aviso por racha).
+    autosave_failed: Cell<bool>,
+    /// Nombre base cacheado (fichero o primera cabecera del borrador); solo
+    /// se recalcula para la pestaña activa, para no leer el texto de todas
+    /// en cada pulsación.
+    display_name: RefCell<String>,
+    /// true mientras hay un dialogo de cierre pendiente para esta pestaña:
+    /// evita dialogos duplicados si se pide cerrarla dos veces.
+    closing: Cell<bool>,
+    page: adw::TabPage,
+}
+
+/// Remate del cierre de una pestaña: confirma/aborta y limpia (ver
+/// `finish_close` en `ScribeWindow::new`).
+type FinishCloseFn = Rc<dyn Fn(&adw::TabPage, bool)>;
+
 pub struct ScribeWindow {
     pub window: adw::ApplicationWindow,
     load_file: Rc<dyn Fn(&Path)>,
+    /// Ancla fuerte de la lista de documentos: los closures registrados en
+    /// objetos de la ventana la capturan en Weak (R3), así que alguien tiene
+    /// que poseerla. La poseen este struct (que main retiene en su registro
+    /// de ventanas) y el temporizador de autoguardado. El binario no la lee
+    /// directamente (solo los smoke tests via page_count/document_count),
+    /// pero su presencia es estructural.
+    #[allow(dead_code)]
+    documents: Rc<RefCell<Vec<Rc<Document>>>>,
+    /// Igual que `documents`: ancla del TabView y superficie de los tests.
+    #[allow(dead_code)]
+    tab_view: adw::TabView,
 }
 
 fn shorten_home(path: &Path) -> String {
@@ -31,6 +71,86 @@ fn shorten_home(path: &Path) -> String {
         }
     }
     s
+}
+
+/// Ruta canónica para deduplicar aperturas (R5/D6); si no se puede
+/// canonicalizar (aún no existe) se usa la ruta tal cual.
+fn canonical(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn file_name_of(path: &Path) -> String {
+    path.file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("Sin título")
+        .to_string()
+}
+
+/// La geometría solo se persiste cuando el cierre de la ventana prospera
+/// (antes se guardaba aunque el usuario cancelara el diálogo de cambios).
+fn persist_geometry(win: &adw::ApplicationWindow, settings: &AppSettings) {
+    let (w, h) = win.default_size();
+    settings.set_window_width(w);
+    settings.set_window_height(h);
+    settings.set_window_maximized(win.is_maximized());
+}
+
+/// Aplica las preferencias a un editor concreto. La usan tanto
+/// `apply_settings` (iterando todos los documentos) como la factoría de
+/// documentos (solo el editor recién creado).
+fn apply_editor_settings(settings: &AppSettings, editor: &Editor) {
+    let size = settings.font_size();
+    editor.set_font(settings.font_family(), size, settings.line_spacing());
+    editor.set_column_width(settings.column_width());
+    editor.set_markup_visibility(settings.markup_visibility());
+    editor.set_focus_mode(settings.focus_mode());
+    editor.set_typewriter_mode(settings.typewriter_mode());
+    editor.set_continue_lists(settings.continue_lists());
+    editor.set_tab_width(settings.tab_width());
+}
+
+/// Refresca título y tooltip de la pestaña de `doc` (D3: «• » si está
+/// modificado; needs_attention solo en las pestañas NO activas) y, si es la
+/// activa, el título de la cabecera y de la ventana.
+fn refresh_doc_tab(
+    doc: &Document,
+    window: &adw::ApplicationWindow,
+    title_widget: &adw::WindowTitle,
+    is_active: bool,
+) {
+    let file = doc.current_file.borrow();
+    let (name, subtitle) = match file.as_ref() {
+        Some(p) => (
+            file_name_of(p),
+            p.parent().map(shorten_home).unwrap_or_default(),
+        ),
+        // Sin fichero, el borrador se identifica por su primera cabecera,
+        // que es lo que el usuario tiene en la cabeza. El texto solo se lee
+        // para la pestaña activa; el resto usa el nombre cacheado.
+        None if is_active => (
+            templates::title_from(&doc.editor.text()).unwrap_or_else(|| "Sin título".to_string()),
+            "Borrador".to_string(),
+        ),
+        None => (doc.display_name.borrow().clone(), "Borrador".to_string()),
+    };
+    let tooltip = match file.as_ref() {
+        Some(p) => p.to_string_lossy().to_string(),
+        None => "Borrador sin guardar".to_string(),
+    };
+    drop(file);
+    if is_active {
+        *doc.display_name.borrow_mut() = name.clone();
+    }
+    let dot = if doc.is_modified.get() { "• " } else { "" };
+    doc.page.set_title(&format!("{dot}{name}"));
+    doc.page.set_tooltip(&tooltip);
+    doc.page
+        .set_needs_attention(!is_active && doc.is_modified.get());
+    if is_active {
+        title_widget.set_title(&format!("{dot}{name}"));
+        title_widget.set_subtitle(&subtitle);
+        window.set_title(Some(&format!("{dot}{name} — Scribe")));
+    }
 }
 
 fn rebuild_toc(list: &gtk4::ListBox, lines_out: &Rc<RefCell<Vec<i32>>>, text: &str) {
@@ -83,14 +203,121 @@ fn rebuild_toc(list: &gtk4::ListBox, lines_out: &Rc<RefCell<Vec<i32>>>, text: &s
     *lines_out.borrow_mut() = lines;
 }
 
+/// Un paso de la cadena de diálogos «Guardar/Descartar/Cancelar» del cierre
+/// de ventana (como GNOME Text Editor): se muestra uno por documento
+/// modificado. Cancelar —o un guardado fallido— aborta toda la secuencia;
+/// al resolverlos todos se invoca `on_done` (que persiste la geometría y
+/// cierra de verdad).
+fn ask_save_step(
+    win: adw::ApplicationWindow,
+    pending: Rc<RefCell<Vec<Rc<Document>>>>,
+    file_manager: Rc<FileManager>,
+    toast: Rc<dyn Fn(&str)>,
+    on_done: Rc<dyn Fn(&adw::ApplicationWindow)>,
+    // Se invoca cuando la cadena se aborta (Cancelar o guardado fallido):
+    // libera la guarda de cierre de la ventana.
+    on_abort: Rc<dyn Fn()>,
+) {
+    let Some(doc) = pending.borrow_mut().pop() else {
+        on_done(&win);
+        return;
+    };
+    let name = doc.display_name.borrow().clone();
+    let dialog = adw::MessageDialog::new(
+        Some(&win),
+        Some(&format!("¿Guardar los cambios en «{name}»?")),
+        Some("Si cierras sin guardar, perderás lo que hayas escrito."),
+    );
+    dialog.add_response("cancel", "Cancelar");
+    dialog.add_response("discard", "Descartar");
+    dialog.add_response("save", "Guardar");
+    dialog.set_response_appearance("discard", adw::ResponseAppearance::Destructive);
+    dialog.set_response_appearance("save", adw::ResponseAppearance::Suggested);
+    dialog.set_default_response(Some("save"));
+    dialog.set_close_response("cancel");
+
+    // Los diálogos son one-shot y acotados: pueden capturar en fuerte (R3).
+    dialog.choose(gio::Cancellable::NONE, move |response| {
+        match response.as_str() {
+            "discard" => {
+                ask_save_step(win, pending, file_manager, toast, on_done, on_abort.clone())
+            }
+            "save" => {
+                let path = doc.current_file.borrow().clone();
+                match path {
+                    Some(p) => match std::fs::write(&p, doc.editor.text()) {
+                        Ok(()) => {
+                            doc.is_modified.set(false);
+                            ask_save_step(
+                                win,
+                                pending,
+                                file_manager,
+                                toast,
+                                on_done,
+                                on_abort.clone(),
+                            );
+                        }
+                        Err(e) => {
+                            toast(&format!("No se pudo guardar: {e}"));
+                            on_abort();
+                        }
+                    },
+                    // Documento sin fichero: se abre «Guardar como»; si el
+                    // usuario cancela ahí, se aborta todo el cierre.
+                    None => {
+                        // El callback de «Guardar como» es otro closure: hay
+                        // que clonar lo que ambos necesitan (no se puede
+                        // mover lo capturado por el closure exterior, Fn).
+                        let win2 = win.clone();
+                        let pending2 = pending.clone();
+                        let fm2 = file_manager.clone();
+                        let toast2 = toast.clone();
+                        let on_done2 = on_done.clone();
+                        let on_abort2 = on_abort.clone();
+                        file_manager.save(&win, None, &doc.editor.text(), move |outcome| {
+                            match outcome {
+                                Outcome::Ok(p) => {
+                                    doc.editor.set_base_dir(p.parent().map(Path::to_path_buf));
+                                    *doc.current_file.borrow_mut() = Some(p);
+                                    doc.is_modified.set(false);
+                                    ask_save_step(
+                                        win2,
+                                        pending2,
+                                        fm2,
+                                        toast2,
+                                        on_done2,
+                                        on_abort2.clone(),
+                                    );
+                                }
+                                Outcome::Error(e) => {
+                                    toast2(&format!("No se pudo guardar: {e}"));
+                                    on_abort2();
+                                }
+                                // Cancelar el «Guardar como» aborta toda la
+                                // cadena de cierre.
+                                Outcome::Cancelled => on_abort2(),
+                            }
+                        });
+                    }
+                }
+            }
+            // Cancelar: se aborta toda la cadena; la ventana sigue abierta.
+            _ => on_abort(),
+        }
+    });
+}
+
 impl ScribeWindow {
     pub fn new(app: &adw::Application, settings: &Rc<AppSettings>) -> Self {
         let settings = settings.clone();
         let file_manager = Rc::new(FileManager::new());
-        let current_file: Rc<RefCell<Option<PathBuf>>> = Rc::new(RefCell::new(None));
-        let is_modified = Rc::new(Cell::new(false));
+        let documents: Rc<RefCell<Vec<Rc<Document>>>> = Rc::new(RefCell::new(Vec::new()));
         let force_close = Rc::new(Cell::new(false));
         let alive = Rc::new(Cell::new(true));
+        // Guarda de «cierre de ventana en curso»: sin ella, pulsar dos veces
+        // el boton de cerrar con dialogos pendientes arrancaba dos cadenas
+        // de «Guardar/Descartar/Cancelar» sobre los mismos documentos.
+        let closing_window = Rc::new(Cell::new(false));
         let toc_lines: Rc<RefCell<Vec<i32>>> = Rc::new(RefCell::new(Vec::new()));
 
         let window = adw::ApplicationWindow::builder()
@@ -102,7 +329,8 @@ impl ScribeWindow {
             window.maximize();
         }
 
-        let editor = Rc::new(Editor::new());
+        // Vista previa compartida (D1/D2): hay UNA por ventana, a la derecha
+        // de todas las pestañas, no dentro de ninguna página.
         let preview = Rc::new(PreviewPanel::new());
         let preview_visible = Rc::new(Cell::new(settings.show_preview()));
 
@@ -160,10 +388,22 @@ impl ScribeWindow {
                 .build(),
         );
 
+        // ============================ PESTAÑAS ===============================
+        // Patrón gnome-text-editor: cada página del AdwTabView es el editor
+        // de un documento; el AdwTabBar va como top bar del ToolbarView.
+        let tab_view = adw::TabView::new();
+        tab_view.set_hexpand(true);
+        tab_view.set_vexpand(true);
+        let tab_bar = adw::TabBar::builder()
+            .view(&tab_view)
+            .autohide(false)
+            .expand_tabs(true)
+            .build();
+
         // ============================== CONTENIDO ==============================
         let paned = gtk4::Paned::builder()
             .orientation(gtk4::Orientation::Horizontal)
-            .start_child(&editor.widget)
+            .start_child(&tab_view)
             .wide_handle(true)
             .position(680)
             .hexpand(true)
@@ -221,6 +461,7 @@ impl ScribeWindow {
         file_section.append(Some("Abrir…"), Some("win.open"));
         file_section.append(Some("Guardar"), Some("win.save"));
         file_section.append(Some("Guardar como…"), Some("win.save-as"));
+        file_section.append(Some("Cerrar pestaña"), Some("win.close-tab"));
         menu.append_section(None, &file_section);
 
         let edit_section = gio::Menu::new();
@@ -330,6 +571,7 @@ impl ScribeWindow {
 
         let toolbar_view = adw::ToolbarView::new();
         toolbar_view.add_top_bar(&header);
+        toolbar_view.add_top_bar(&tab_bar);
         toolbar_view.add_bottom_bar(&status_bar);
         toolbar_view.set_content(Some(&paned));
 
@@ -356,41 +598,49 @@ impl ScribeWindow {
             Rc::new(move |msg: &str| toasts.add_toast(adw::Toast::new(msg)))
         };
 
-        let update_title: Rc<dyn Fn()> = {
-            let current_file = current_file.clone();
-            let is_modified = is_modified.clone();
-            let title_widget = title_widget.clone();
-            // Débiles: este closure acaba dentro de las señales del editor
-            // (on_changed), que cuelga de la propia ventana; en fuerte sería
-            // un ciclo (Editor → callback → Editor) y ni la ventana ni el
-            // editor se liberarían jamás.
-            let window = window.downgrade();
-            let editor = Rc::downgrade(&editor);
+        // Resuelve el documento de la pestaña activa. Las acciones de
+        // formato/guardado lo llaman en cada activación (D10/R7): ninguna
+        // captura un editor concreto. Débil hacia la lista de documentos:
+        // este closure acaba registrado en acciones y señales de la propia
+        // ventana y en fuerte sería un ciclo (R3).
+        let active_document: Rc<dyn Fn() -> Option<Rc<Document>>> = {
+            let documents = Rc::downgrade(&documents);
+            // Debil: update_status/update_counts lo capturan y estan
+            // registrados en el propio TabView y en los buffers (R3).
+            let tab_view = tab_view.downgrade();
             Rc::new(move || {
-                let (Some(window), Some(editor)) = (window.upgrade(), editor.upgrade()) else {
+                let docs = documents.upgrade()?;
+                let tab_view = tab_view.upgrade()?;
+                let page = tab_view.selected_page()?;
+                // En una expresion de cola el Ref temporal vivira mas que
+                // `docs`; se fuerza su caida antes con una variable local.
+                let found = docs.borrow().iter().find(|d| d.page == page).cloned();
+                found
+            })
+        };
+
+        // Refresca el título de TODAS las pestañas (punto «• », tooltip y
+        // needs_attention, también en las no activas) y el título de la
+        // cabecera y la ventana con la pestaña activa.
+        let refresh_tabs: Rc<dyn Fn()> = {
+            // Débiles: véase active_document. tab_view tambien va en debil:
+            // este closure lo capturan las senales DEL PROPIO TabView y en
+            // fuerte seria un ciclo (R3, revision de pestañas).
+            let window = window.downgrade();
+            let documents = Rc::downgrade(&documents);
+            let title_widget = title_widget.clone();
+            let tab_view = tab_view.downgrade();
+            Rc::new(move || {
+                let (Some(window), Some(docs), Some(tab_view)) =
+                    (window.upgrade(), documents.upgrade(), tab_view.upgrade())
+                else {
                     return;
                 };
-                let file = current_file.borrow();
-                let (name, subtitle) = match file.as_ref() {
-                    Some(p) => (
-                        p.file_name()
-                            .and_then(|s| s.to_str())
-                            .unwrap_or("Sin título")
-                            .to_string(),
-                        p.parent().map(shorten_home).unwrap_or_default(),
-                    ),
-                    // Sin fichero, el borrador se identifica por su primera
-                    // cabecera, que es lo que el usuario tiene en la cabeza.
-                    None => (
-                        templates::title_from(&editor.text())
-                            .unwrap_or_else(|| "Sin título".to_string()),
-                        "Borrador".to_string(),
-                    ),
-                };
-                let dot = if is_modified.get() { "• " } else { "" };
-                title_widget.set_title(&format!("{dot}{name}"));
-                title_widget.set_subtitle(&subtitle);
-                window.set_title(Some(&format!("{dot}{name} — Scribe")));
+                let selected = tab_view.selected_page();
+                for doc in docs.borrow().iter() {
+                    let is_active = selected.as_ref() == Some(&doc.page);
+                    refresh_doc_tab(doc, &window, &title_widget, is_active);
+                }
             })
         };
 
@@ -399,17 +649,16 @@ impl ScribeWindow {
         // timeout ya debounced de connect_changed, reutilizando la copia del
         // texto que se hace para la vista previa y el índice.
         let update_counts: Rc<dyn Fn(&str)> = {
-            // Débil: véase update_title.
-            let editor = Rc::downgrade(&editor);
+            let active_document = active_document.clone();
             let words_label = words_label.clone();
             let props_label = props_label.clone();
             Rc::new(move |text: &str| {
-                let Some(editor) = editor.upgrade() else {
+                let Some(doc) = active_document() else {
                     return;
                 };
                 let words = text.split_whitespace().count();
                 let chars = text.chars().count();
-                let lines = editor.line_count();
+                let lines = doc.editor.line_count();
                 words_label.set_label(&format!("{words} palabras"));
                 let minutes = (words as f64 / 200.0).ceil().max(1.0) as usize;
                 props_label.set_label(&format!(
@@ -419,17 +668,16 @@ impl ScribeWindow {
         };
 
         let update_status: Rc<dyn Fn()> = {
-            // Débil: véase update_title.
-            let editor = Rc::downgrade(&editor);
+            let active_document = active_document.clone();
             let position_button = position_button.clone();
             let goto_spin = goto_spin.clone();
             let goto_popover = goto_popover.clone();
             Rc::new(move || {
-                let Some(editor) = editor.upgrade() else {
+                let Some(doc) = active_document() else {
                     return;
                 };
-                let lines = editor.line_count();
-                let (line, column) = editor.cursor_position();
+                let lines = doc.editor.line_count();
+                let (line, column) = doc.editor.cursor_position();
                 position_button.set_label(&format!("Ln {line}, Col {column}"));
                 // Con el popover «Ir a la línea» abierto el spin es del
                 // usuario: no pisar lo que está escribiendo.
@@ -525,50 +773,284 @@ impl ScribeWindow {
         };
         refresh_templates();
 
-        let load_file: Rc<dyn Fn(&Path)> = {
-            let editor = editor.clone();
-            let current_file = current_file.clone();
-            let is_modified = is_modified.clone();
+        // ---- aplicar preferencias ----
+        let apply_settings: Rc<dyn Fn()> = {
             let settings = settings.clone();
-            let update_title = update_title.clone();
-            let update_status = update_status.clone();
+            let documents = Rc::downgrade(&documents);
+            let preview = preview.clone();
+            let zoom_label = zoom_label.clone();
             let refresh_recents = refresh_recents.clone();
+            let refresh_templates = refresh_templates.clone();
+            Rc::new(move || {
+                adw::StyleManager::default().set_color_scheme(
+                    match settings.color_scheme_index() {
+                        1 => adw::ColorScheme::ForceLight,
+                        2 => adw::ColorScheme::ForceDark,
+                        _ => adw::ColorScheme::Default,
+                    },
+                );
+                // Las preferencias del editor son globales: se aplican a
+                // todos los documentos abiertos.
+                if let Some(docs) = documents.upgrade() {
+                    for doc in docs.borrow().iter() {
+                        apply_editor_settings(&settings, &doc.editor);
+                    }
+                }
+                preview.set_font_size(settings.font_size());
+                zoom_label.set_label(&format!("{}px", settings.font_size()));
+                refresh_recents("");
+                refresh_templates();
+            })
+        };
+        apply_settings();
+
+        // ======================= FACTORÍA DE DOCUMENTOS ======================
+        // Crea el editor, le aplica las preferencias, monta su pestaña y
+        // cablea sus señales. Todo closure registrado en el editor o en la
+        // ventana captura Weak del Document o de la lista (R3); los timeouts
+        // one-shot acotados pueden capturar en fuerte.
+        let create_document: CreateDocument = {
+            let settings = settings.clone();
+            let documents = Rc::downgrade(&documents);
+            // Debil: finish_close (que lo captura) vive en una senal del
+            // propio TabView; en fuerte seria un ciclo (R3).
+            let tab_view = tab_view.downgrade();
+            let preview = preview.clone();
+            let preview_visible = preview_visible.clone();
+            let toc_list = toc_list.clone();
+            let toc_lines = toc_lines.clone();
+            let refresh_tabs = refresh_tabs.clone();
+            let update_status = update_status.clone();
+            let update_counts = update_counts.clone();
+            Rc::new(move |body: String, file: Option<PathBuf>| {
+                // Solo puede fallar con la ventana destruyendose, cuando
+                // nadie deberia crear documentos.
+                let tab_view = tab_view.upgrade().expect("ventana viva al crear documento");
+                let editor = Rc::new(Editor::new());
+                apply_editor_settings(&settings, &editor);
+                if !body.is_empty() {
+                    editor.set_text(&body);
+                }
+                // Documento sin fichero: las imágenes relativas no se
+                // resuelven y se pinta el placeholder.
+                editor.set_base_dir(
+                    file.as_ref()
+                        .and_then(|p| p.parent().map(Path::to_path_buf)),
+                );
+
+                let page = tab_view.append(&editor.widget);
+                let display_name = match &file {
+                    Some(p) => file_name_of(p),
+                    None => {
+                        templates::title_from(&body).unwrap_or_else(|| "Sin título".to_string())
+                    }
+                };
+                let doc = Rc::new(Document {
+                    editor,
+                    current_file: RefCell::new(file),
+                    is_modified: Cell::new(false),
+                    autosave_elapsed: Cell::new(0),
+                    autosave_failed: Cell::new(false),
+                    display_name: RefCell::new(display_name),
+                    closing: Cell::new(false),
+                    page,
+                });
+
+                // ---- cableado por documento ----
+                {
+                    // Débil: Document → Editor → callback → Document sería un
+                    // ciclo y ni la pestaña ni el editor se liberarían jamás.
+                    let doc_weak = Rc::downgrade(&doc);
+                    // Debil: este handler vive en el buffer, que cuelga del
+                    // propio TabView; en fuerte seria un ciclo (R3).
+                    let tab_view = tab_view.downgrade();
+                    let refresh_tabs = refresh_tabs.clone();
+                    let update_status = update_status.clone();
+                    let update_counts = update_counts.clone();
+                    let preview = preview.clone();
+                    let preview_visible = preview_visible.clone();
+                    let toc_list = toc_list.clone();
+                    let toc_lines = toc_lines.clone();
+                    let generation = Rc::new(Cell::new(0u64));
+                    doc.editor.connect_changed(move |text| {
+                        let Some(doc) = doc_weak.upgrade() else {
+                            return;
+                        };
+                        if !doc.is_modified.replace(true) {
+                            // Primera modificación: actualiza el «• » y el
+                            // needs_attention de todas las pestañas.
+                            refresh_tabs();
+                        }
+                        // Contadores, TOC y vista previa solo siguen a la
+                        // pestaña activa.
+                        let Some(tab_view) = tab_view.upgrade() else {
+                            return;
+                        };
+                        if tab_view.selected_page().as_ref() != Some(&doc.page) {
+                            return;
+                        }
+                        update_status();
+
+                        let current = generation.get().wrapping_add(1);
+                        generation.set(current);
+                        let text = text.to_string();
+                        let generation = generation.clone();
+                        let doc_weak = doc_weak.clone();
+                        let tab_view = tab_view.clone();
+                        let preview = preview.clone();
+                        let preview_visible = preview_visible.clone();
+                        let toc_list = toc_list.clone();
+                        let toc_lines = toc_lines.clone();
+                        let update_counts = update_counts.clone();
+                        glib::timeout_add_local_once(Duration::from_millis(120), move || {
+                            if generation.get() != current {
+                                return;
+                            }
+                            let Some(doc) = doc_weak.upgrade() else {
+                                return;
+                            };
+                            // Si mientras tanto se cambió de pestaña, este
+                            // refresco ya no interesa.
+                            if tab_view.selected_page().as_ref() != Some(&doc.page) {
+                                return;
+                            }
+                            update_counts(&text);
+                            if preview_visible.get() {
+                                preview.update(&text);
+                            }
+                            rebuild_toc(&toc_list, &toc_lines, &text);
+                        });
+                    });
+                }
+                {
+                    let update_status = update_status.clone();
+                    doc.editor.connect_cursor_moved(move || update_status());
+                }
+
+                if let Some(docs) = documents.upgrade() {
+                    docs.borrow_mut().push(doc.clone());
+                }
+                tab_view.set_selected_page(&doc.page);
+                refresh_tabs();
+                update_status();
+                let text = doc.editor.text();
+                update_counts(&text);
+                if preview_visible.get() {
+                    preview.update(&text);
+                }
+                rebuild_toc(&toc_list, &toc_lines, &text);
+                doc
+            })
+        };
+
+        // Inserta un fichero ya leído: deduplica por ruta canónica (D6/R5),
+        // reutiliza la pestaña virgen si es la única y crea pestaña nueva en
+        // cualquier otro caso.
+        let open_loaded: Rc<dyn Fn(PathBuf, String)> = {
+            let documents = Rc::downgrade(&documents);
+            let tab_view = tab_view.clone();
+            let settings = settings.clone();
+            let create_document = create_document.clone();
+            let refresh_recents = refresh_recents.clone();
+            let refresh_tabs = refresh_tabs.clone();
+            let update_status = update_status.clone();
+            Rc::new(move |path: PathBuf, content: String| {
+                let Some(docs) = documents.upgrade() else {
+                    return;
+                };
+                let canon = canonical(&path);
+                let existing = docs
+                    .borrow()
+                    .iter()
+                    .find(|d| {
+                        d.current_file
+                            .borrow()
+                            .as_ref()
+                            .is_some_and(|p| canonical(p) == canon)
+                    })
+                    .cloned();
+                if let Some(existing) = existing {
+                    tab_view.set_selected_page(&existing.page);
+                    return;
+                }
+
+                // Si solo hay una pestaña virgen (sin fichero, sin cambios y
+                // vacía) se reutiliza en vez de abrir otra, como hace gedit.
+                let pristine = {
+                    let list = docs.borrow();
+                    match list.as_slice() {
+                        [d] if d.current_file.borrow().is_none()
+                            && !d.is_modified.get()
+                            && d.editor.text().is_empty() =>
+                        {
+                            Some(d.clone())
+                        }
+                        _ => None,
+                    }
+                };
+                if let Some(doc) = pristine {
+                    doc.editor.set_text(&content);
+                    doc.editor
+                        .set_base_dir(path.parent().map(Path::to_path_buf));
+                    *doc.current_file.borrow_mut() = Some(path.clone());
+                    doc.is_modified.set(false);
+                    *doc.display_name.borrow_mut() = file_name_of(&path);
+                    tab_view.set_selected_page(&doc.page);
+                } else {
+                    create_document(content, Some(path.clone()));
+                }
+                settings.push_recent_file(&path.to_string_lossy());
+                refresh_recents("");
+                refresh_tabs();
+                update_status();
+            })
+        };
+
+        let load_file: Rc<dyn Fn(&Path)> = {
+            let open_loaded = open_loaded.clone();
             let toast = toast.clone();
             Rc::new(move |path: &Path| match std::fs::read_to_string(path) {
-                Ok(content) => {
-                    editor.set_text(&content);
-                    editor.set_base_dir(path.parent().map(Path::to_path_buf));
-                    *current_file.borrow_mut() = Some(path.to_path_buf());
-                    is_modified.set(false);
-                    settings.push_recent_file(&path.to_string_lossy());
-                    refresh_recents("");
-                    update_title();
-                    update_status();
-                }
+                Ok(content) => open_loaded(path.to_path_buf(), content),
                 Err(e) => toast(&format!("No se pudo abrir: {e}")),
             })
         };
 
         let new_document: NewDocument = {
-            let editor = editor.clone();
-            let current_file = current_file.clone();
-            let is_modified = is_modified.clone();
-            let update_title = update_title.clone();
-            let update_status = update_status.clone();
+            let create_document = create_document.clone();
             Rc::new(move |template_name: Option<&str>| {
                 let body = template_name
                     .and_then(templates::find)
                     .and_then(|t| t.body())
                     .map(|b| templates::render(&b, "Sin título"))
                     .unwrap_or_default();
-                editor.set_text(&body);
-                // Documento sin fichero: las imágenes relativas no se
-                // resuelven y se pinta el placeholder.
-                editor.set_base_dir(None);
-                *current_file.borrow_mut() = None;
-                is_modified.set(false);
-                update_title();
-                update_status();
+                create_document(body, None);
+            })
+        };
+
+        // Remata el cierre de una pestaña pedido con close_page: confirma o
+        // aborta, limpia la lista de documentos y aplica D5 (al cerrar la
+        // última pestaña se abre una en blanco; la ventana solo se cierra
+        // por cierre de ventana).
+        let finish_close: FinishCloseFn = {
+            let documents = Rc::downgrade(&documents);
+            // Debil: este closure lo captura la senal close-page del propio
+            // TabView; en fuerte seria un ciclo (R3).
+            let tab_view = tab_view.downgrade();
+            let create_document = create_document.clone();
+            Rc::new(move |page, confirm| {
+                let Some(tab_view) = tab_view.upgrade() else {
+                    return;
+                };
+                tab_view.close_page_finish(page, confirm);
+                if !confirm {
+                    return;
+                }
+                if let Some(docs) = documents.upgrade() {
+                    docs.borrow_mut().retain(|d| d.page != *page);
+                }
+                if tab_view.n_pages() == 0 {
+                    create_document(String::new(), None);
+                }
             })
         };
 
@@ -590,6 +1072,9 @@ impl ScribeWindow {
         let action_italic = gio::SimpleAction::new("italic", None);
         let action_code = gio::SimpleAction::new("code", None);
         let action_format_tables = gio::SimpleAction::new("format-tables", None);
+        let action_close_tab = gio::SimpleAction::new("close-tab", None);
+        let action_tab_next = gio::SimpleAction::new("tab-next", None);
+        let action_tab_prev = gio::SimpleAction::new("tab-prev", None);
 
         // Las alternancias son con estado, para que el menú muestre la marca.
         let action_sidebar = gio::SimpleAction::new_stateful(
@@ -627,6 +1112,9 @@ impl ScribeWindow {
             &action_italic,
             &action_code,
             &action_format_tables,
+            &action_close_tab,
+            &action_tab_next,
+            &action_tab_prev,
         ] {
             window.add_action(a);
         }
@@ -637,20 +1125,28 @@ impl ScribeWindow {
         window.add_action(&action_focus);
         window.add_action(&action_typewriter);
 
+        // ---- formato: siempre sobre la pestaña activa, resuelta al vuelo ----
         for (action, marker) in [
             (&action_bold, "**"),
             (&action_italic, "*"),
             (&action_code, "`"),
         ] {
-            let editor = editor.clone();
-            action.connect_activate(move |_, _| editor.wrap_selection(marker));
+            let active_document = active_document.clone();
+            action.connect_activate(move |_, _| {
+                if let Some(doc) = active_document() {
+                    doc.editor.wrap_selection(marker);
+                }
+            });
         }
 
         {
-            let editor = editor.clone();
+            let active_document = active_document.clone();
             let toast = toast.clone();
             action_format_tables.connect_activate(move |_, _| {
-                if editor.format_tables() {
+                let Some(doc) = active_document() else {
+                    return;
+                };
+                if doc.editor.format_tables() {
                     toast("Tablas alineadas");
                 } else {
                     toast("No hay tablas que alinear");
@@ -658,37 +1154,29 @@ impl ScribeWindow {
             });
         }
 
-        // ---- aplicar preferencias ----
-        let apply_settings: Rc<dyn Fn()> = {
-            let settings = settings.clone();
-            let editor = editor.clone();
-            let preview = preview.clone();
-            let zoom_label = zoom_label.clone();
-            let refresh_recents = refresh_recents.clone();
-            let refresh_templates = refresh_templates.clone();
-            Rc::new(move || {
-                adw::StyleManager::default().set_color_scheme(
-                    match settings.color_scheme_index() {
-                        1 => adw::ColorScheme::ForceLight,
-                        2 => adw::ColorScheme::ForceDark,
-                        _ => adw::ColorScheme::Default,
-                    },
-                );
-                let size = settings.font_size();
-                editor.set_font(settings.font_family(), size, settings.line_spacing());
-                editor.set_column_width(settings.column_width());
-                editor.set_markup_visibility(settings.markup_visibility());
-                editor.set_focus_mode(settings.focus_mode());
-                editor.set_typewriter_mode(settings.typewriter_mode());
-                editor.set_continue_lists(settings.continue_lists());
-                editor.set_tab_width(settings.tab_width());
-                preview.set_font_size(size);
-                zoom_label.set_label(&format!("{}px", size));
-                refresh_recents("");
-                refresh_templates();
-            })
-        };
-        apply_settings();
+        // ---- pestañas ----
+        {
+            let tab_view = tab_view.clone();
+            action_close_tab.connect_activate(move |_, _| {
+                if let Some(page) = tab_view.selected_page() {
+                    // close_page dispara la señal close-page, donde se
+                    // confirma o se veta según haya cambios.
+                    tab_view.close_page(&page);
+                }
+            });
+        }
+        {
+            let tab_view = tab_view.clone();
+            action_tab_next.connect_activate(move |_, _| {
+                tab_view.select_next_page();
+            });
+        }
+        {
+            let tab_view = tab_view.clone();
+            action_tab_prev.connect_activate(move |_, _| {
+                tab_view.select_previous_page();
+            });
+        }
 
         {
             // Débil: la ventana posee sus acciones; una captura fuerte aquí
@@ -766,37 +1254,16 @@ impl ScribeWindow {
             // Débil: véase action_preferences.
             let window = window.downgrade();
             let file_manager = file_manager.clone();
-            let editor = editor.clone();
-            let current_file = current_file.clone();
-            let is_modified = is_modified.clone();
-            let settings = settings.clone();
-            let update_title = update_title.clone();
-            let update_status = update_status.clone();
-            let refresh_recents = refresh_recents.clone();
+            let open_loaded = open_loaded.clone();
             let toast = toast.clone();
             action_open.connect_activate(move |_, _| {
                 let Some(window) = window.upgrade() else {
                     return;
                 };
-                let editor = editor.clone();
-                let current_file = current_file.clone();
-                let is_modified = is_modified.clone();
-                let settings = settings.clone();
-                let update_title = update_title.clone();
-                let update_status = update_status.clone();
-                let refresh_recents = refresh_recents.clone();
+                let open_loaded = open_loaded.clone();
                 let toast = toast.clone();
                 file_manager.open(&window, move |outcome| match outcome {
-                    OpenOutcome::Ok((path, content)) => {
-                        editor.set_text(&content);
-                        editor.set_base_dir(path.parent().map(Path::to_path_buf));
-                        *current_file.borrow_mut() = Some(path.clone());
-                        is_modified.set(false);
-                        settings.push_recent_file(&path.to_string_lossy());
-                        refresh_recents("");
-                        update_title();
-                        update_status();
-                    }
+                    OpenOutcome::Ok((path, content)) => open_loaded(path, content),
                     OpenOutcome::Error(e) => toast(&e),
                     OpenOutcome::Cancelled => {}
                 });
@@ -807,44 +1274,87 @@ impl ScribeWindow {
             // Débil: véase action_preferences.
             let window = window.downgrade();
             let file_manager = file_manager.clone();
-            let editor = editor.clone();
-            let current_file = current_file.clone();
-            let is_modified = is_modified.clone();
+            let active_document = active_document.clone();
+            let documents = Rc::downgrade(&documents);
+            let tab_view = tab_view.downgrade();
             let settings = settings.clone();
-            let update_title = update_title.clone();
             let refresh_recents = refresh_recents.clone();
+            let refresh_tabs = refresh_tabs.clone();
             let toast = toast.clone();
             move |_: &gio::SimpleAction, _: Option<&glib::Variant>| {
                 let Some(window) = window.upgrade() else {
                     return;
                 };
-                let content = editor.text();
+                // D10/R7: el documento se resuelve en cada activación.
+                let Some(doc) = active_document() else {
+                    return;
+                };
+                let content = doc.editor.text();
                 let path = if force_dialog {
                     None
                 } else {
-                    current_file.borrow().clone()
+                    doc.current_file.borrow().clone()
                 };
-                let current_file = current_file.clone();
-                let is_modified = is_modified.clone();
                 let settings = settings.clone();
-                let update_title = update_title.clone();
                 let refresh_recents = refresh_recents.clone();
+                let refresh_tabs = refresh_tabs.clone();
                 let toast = toast.clone();
-                let editor = editor.clone();
+                // Clones del Weak para el callback one-shot (no se puede
+                // mover lo capturado por este closure Fn).
+                let documents = documents.clone();
+                let tab_view = tab_view.clone();
                 file_manager.save(
                     &window,
                     path.as_ref(),
                     &content,
+                    // Callback one-shot y acotado: puede capturar el
+                    // documento en fuerte.
                     move |outcome| match outcome {
                         Outcome::Ok(p) => {
+                            // R5 ampliado (revision): «Guardar como» sobre la
+                            // ruta de OTRA pestaña abierta crearia dos
+                            // buffers para el mismo fichero y el
+                            // autoguardado los haria pisarse. Se aborta y se
+                            // enfoca la pestaña que ya lo tiene.
+                            if let (Some(docs), Some(tv)) =
+                                (documents.upgrade(), tab_view.upgrade())
+                            {
+                                let canon_new = canonical(&p);
+                                let otro = docs
+                                    .borrow()
+                                    .iter()
+                                    .find(|d| {
+                                        !Rc::ptr_eq(d, &doc)
+                                            && d.current_file
+                                                .borrow()
+                                                .as_ref()
+                                                .map(|q| canonical(q))
+                                                .as_ref()
+                                                == Some(&canon_new)
+                                    })
+                                    .cloned();
+                                if let Some(otro) = otro {
+                                    // Limitacion conocida: FileManager::save
+                                    // ya escribio el fichero al llegar aqui
+                                    // (el usuario confirmo la sobrescritura
+                                    // en el dialogo); lo que se evita es el
+                                    // estado persistente de dos buffers para
+                                    // un mismo fichero.
+                                    tv.set_selected_page(&otro.page);
+                                    toast("Ese fichero ya está abierto en otra pestaña");
+                                    return;
+                                }
+                            }
                             // Tras «guardar como» el directorio base de las
                             // imágenes puede haber cambiado.
-                            editor.set_base_dir(p.parent().map(Path::to_path_buf));
-                            *current_file.borrow_mut() = Some(p.clone());
-                            is_modified.set(false);
+                            doc.editor.set_base_dir(p.parent().map(Path::to_path_buf));
+                            *doc.current_file.borrow_mut() = Some(p.clone());
+                            doc.is_modified.set(false);
+                            *doc.display_name.borrow_mut() = file_name_of(&p);
                             settings.push_recent_file(&p.to_string_lossy());
                             refresh_recents("");
-                            update_title();
+                            // Actualiza título y tooltip (ruta) de la pestaña.
+                            refresh_tabs();
                             toast("Guardado");
                         }
                         Outcome::Error(e) => toast(&e),
@@ -871,13 +1381,16 @@ impl ScribeWindow {
             let paned = paned.clone();
             let preview = preview.clone();
             let preview_visible = preview_visible.clone();
-            let editor = editor.clone();
+            let active_document = active_document.clone();
             let settings = settings.clone();
             action_preview.connect_activate(move |action, _| {
                 let next = !preview_visible.get();
                 preview_visible.set(next);
                 if next {
-                    preview.update(&editor.text());
+                    // Vista previa compartida: se alimenta de la activa.
+                    if let Some(doc) = active_document() {
+                        preview.update(&doc.editor.text());
+                    }
                     paned.set_end_child(Some(&preview.widget));
                 } else {
                     paned.set_end_child(None::<&gtk4::Widget>);
@@ -887,7 +1400,8 @@ impl ScribeWindow {
             });
         }
         for (action, is_focus) in [(&action_focus, true), (&action_typewriter, false)] {
-            let editor = editor.clone();
+            // Débil: estos modos se aplican a todos los editores.
+            let documents = Rc::downgrade(&documents);
             let settings = settings.clone();
             action.connect_activate(move |action, _| {
                 let next = !action
@@ -897,10 +1411,17 @@ impl ScribeWindow {
                 action.set_state(&next.to_variant());
                 if is_focus {
                     settings.set_focus_mode(next);
-                    editor.set_focus_mode(next);
                 } else {
                     settings.set_typewriter_mode(next);
-                    editor.set_typewriter_mode(next);
+                }
+                if let Some(docs) = documents.upgrade() {
+                    for doc in docs.borrow().iter() {
+                        if is_focus {
+                            doc.editor.set_focus_mode(next);
+                        } else {
+                            doc.editor.set_typewriter_mode(next);
+                        }
+                    }
                 }
             });
         }
@@ -930,141 +1451,76 @@ impl ScribeWindow {
         }
 
         // ============================== SEÑALES ================================
+        // ---- cambio de pestaña: refresca título, contadores, posición,
+        // TOC, vista previa y quita el needs_attention de la nueva activa ----
         {
+            let documents = Rc::downgrade(&documents);
+            let refresh_tabs = refresh_tabs.clone();
+            let update_status = update_status.clone();
+            let update_counts = update_counts.clone();
             let preview = preview.clone();
             let preview_visible = preview_visible.clone();
             let toc_list = toc_list.clone();
             let toc_lines = toc_lines.clone();
-            let is_modified = is_modified.clone();
-            let update_title = update_title.clone();
-            let update_status = update_status.clone();
-            let update_counts = update_counts.clone();
-            let generation = Rc::new(Cell::new(0u64));
-            editor.connect_changed(move |text| {
-                if !is_modified.replace(true) {
-                    update_title();
-                }
+            tab_view.connect_selected_page_notify(move |tv| {
+                refresh_tabs();
                 update_status();
-
-                let current = generation.get().wrapping_add(1);
-                generation.set(current);
-                let text = text.to_string();
-                let generation = generation.clone();
-                let preview = preview.clone();
-                let preview_visible = preview_visible.clone();
-                let toc_list = toc_list.clone();
-                let toc_lines = toc_lines.clone();
-                let update_counts = update_counts.clone();
-                glib::timeout_add_local_once(Duration::from_millis(120), move || {
-                    if generation.get() != current {
-                        return;
-                    }
-                    update_counts(&text);
-                    if preview_visible.get() {
-                        preview.update(&text);
-                    }
-                    rebuild_toc(&toc_list, &toc_lines, &text);
-                });
-            });
-        }
-        {
-            let update_status = update_status.clone();
-            editor.connect_cursor_moved(move || update_status());
-        }
-        {
-            let toc_lines = toc_lines.clone();
-            let editor = editor.clone();
-            toc_list.connect_row_activated(move |_, row| {
-                let line = toc_lines.borrow().get(row.index() as usize).copied();
-                if let Some(line) = line {
-                    editor.scroll_to_line(line);
+                let (Some(docs), Some(page)) = (documents.upgrade(), tv.selected_page()) else {
+                    return;
+                };
+                let Some(doc) = docs.borrow().iter().find(|d| d.page == page).cloned() else {
+                    return;
+                };
+                let text = doc.editor.text();
+                update_counts(&text);
+                if preview_visible.get() {
+                    preview.update(&text);
                 }
-            });
-        }
-        {
-            let refresh_recents = refresh_recents.clone();
-            search_entry
-                .connect_search_changed(move |entry| refresh_recents(entry.text().as_str()));
-        }
-        {
-            let editor = editor.clone();
-            let goto_spin = goto_spin.clone();
-            let goto_popover = goto_popover.clone();
-            goto_button.connect_clicked(move |_| {
-                editor.go_to_line(goto_spin.value() as i32);
-                goto_popover.popdown();
+                rebuild_toc(&toc_list, &toc_lines, &text);
             });
         }
 
-        // ---- autoguardado ----
+        // ---- cierre de pestaña (botón de la TabBar o win.close-tab) ----
         {
-            let settings = settings.clone();
-            let editor = editor.clone();
-            let current_file = current_file.clone();
-            let is_modified = is_modified.clone();
-            let update_title = update_title.clone();
-            let toast = toast.clone();
-            let alive = alive.clone();
-            let elapsed = Cell::new(0i32);
-            // El temporizador se repite: se avisa una vez por racha de fallos,
-            // no en cada ciclo.
-            let failed = Cell::new(false);
-            glib::timeout_add_seconds_local(5, move || {
-                if !alive.get() {
-                    return glib::ControlFlow::Break;
-                }
-                elapsed.set(elapsed.get() + 5);
-                if elapsed.get() < settings.autosave_interval() {
-                    return glib::ControlFlow::Continue;
-                }
-                elapsed.set(0);
-                if settings.autosave() && is_modified.get() {
-                    let path = current_file.borrow().clone();
-                    if let Some(path) = path {
-                        match std::fs::write(&path, editor.text()) {
-                            Ok(()) => {
-                                is_modified.set(false);
-                                update_title();
-                                failed.set(false);
-                            }
-                            // Sin este aviso el usuario confía en una copia
-                            // automática que no existe.
-                            Err(e) => {
-                                if !failed.replace(true) {
-                                    toast(&format!("No se pudo autoguardar: {e}"));
-                                }
-                            }
-                        }
-                    }
-                }
-                glib::ControlFlow::Continue
-            });
-        }
-
-        // ---- cierre ----
-        {
-            let settings = settings.clone();
-            let is_modified = is_modified.clone();
-            let force_close = force_close.clone();
-            let alive = alive.clone();
-            let current_file = current_file.clone();
-            let editor = editor.clone();
+            // Débiles: esta señal vive en el TabView, que es de la ventana.
+            let documents = Rc::downgrade(&documents);
+            let window_weak = window.downgrade();
             let file_manager = file_manager.clone();
+            let finish_close = finish_close.clone();
             let toast = toast.clone();
-            window.connect_close_request(move |win| {
-                let (w, h) = win.default_size();
-                settings.set_window_width(w);
-                settings.set_window_height(h);
-                settings.set_window_maximized(win.is_maximized());
-
-                if force_close.get() || !is_modified.get() {
-                    alive.set(false);
+            tab_view.connect_close_page(move |_, page| {
+                // Veto siempre (Stop): el cierre y su limpieza los rematamos
+                // nosotros con close_page_finish. Solo se deja pasar el
+                // cierre por defecto si el documento ya no está localizable
+                // (ventana destruyéndose), pues entonces no hay nada que
+                // limpiar.
+                let Some(docs) = documents.upgrade() else {
+                    // Inalcanzable en la practica: el TabView no emite
+                    // close-page durante la destruccion de la ventana. Si
+                    // ocurriera, el cierre por defecto dejaria el Document
+                    // huerfano en la lista (no hay retain aqui).
                     return glib::Propagation::Proceed;
+                };
+                let Some(doc) = docs.borrow().iter().find(|d| &d.page == page).cloned() else {
+                    return glib::Propagation::Proceed;
+                };
+                if !doc.is_modified.get() {
+                    finish_close(page, true);
+                    return glib::Propagation::Stop;
                 }
+                if doc.closing.replace(true) {
+                    // Ya hay un dialogo de cierre pendiente para esta
+                    // pestaña: veto sin abrir otro (el primero remata).
+                    return glib::Propagation::Stop;
+                }
+                let Some(win) = window_weak.upgrade() else {
+                    return glib::Propagation::Proceed;
+                };
 
+                let name = doc.display_name.borrow().clone();
                 let dialog = adw::MessageDialog::new(
-                    Some(win),
-                    Some("¿Guardar los cambios?"),
+                    Some(&win),
+                    Some(&format!("¿Guardar los cambios en «{name}»?")),
                     Some("Si cierras sin guardar, perderás lo que hayas escrito."),
                 );
                 dialog.add_response("cancel", "Cancelar");
@@ -1075,66 +1531,234 @@ impl ScribeWindow {
                 dialog.set_default_response(Some("save"));
                 dialog.set_close_response("cancel");
 
-                let win = win.clone();
-                let force_close = force_close.clone();
-                let current_file = current_file.clone();
-                let editor = editor.clone();
-                let file_manager = file_manager.clone();
+                // El diálogo es one-shot y acotado: capturas en fuerte (R3).
+                // Todo lo que el callback mueve debe ser local de esta
+                // invocacion: lo capturado por el closure Fn exterior no se
+                // puede mover, asi que se clona antes (sombras).
+                let page = page.clone();
+                let finish_close = finish_close.clone();
                 let toast = toast.clone();
+                let file_manager = file_manager.clone();
                 dialog.choose(gio::Cancellable::NONE, move |response| {
                     match response.as_str() {
-                        "discard" => {
-                            force_close.set(true);
-                            win.close();
-                        }
+                        "discard" => finish_close(&page, true),
                         "save" => {
-                            let path = current_file.borrow().clone();
+                            let path = doc.current_file.borrow().clone();
                             match path {
-                                Some(p) => match std::fs::write(&p, editor.text()) {
+                                Some(p) => match std::fs::write(&p, doc.editor.text()) {
                                     Ok(()) => {
-                                        force_close.set(true);
-                                        win.close();
+                                        doc.is_modified.set(false);
+                                        finish_close(&page, true);
                                     }
-                                    Err(e) => toast(&format!("No se pudo guardar: {e}")),
+                                    // Un guardado fallido aborta el cierre:
+                                    // el usuario decide qué hacer después.
+                                    Err(e) => {
+                                        toast(&format!("No se pudo guardar: {e}"));
+                                        // Aborto: liberar la guarda de
+                                        // cierre de esta pestaña.
+                                        doc.closing.set(false);
+                                        finish_close(&page, false);
+                                    }
                                 },
-                                // Documento sin fichero: se abre «Guardar como» y
-                                // la ventana debe cerrarse al terminar; si no, el
-                                // usuario se queda con ella abierta tras pedir
-                                // guardar y cerrar.
+                                // Documento sin fichero: «Guardar como»; si
+                                // se cancela ahí, la pestaña no se cierra.
                                 None => {
-                                    let parent = win.clone();
-                                    let win = win.clone();
-                                    let force_close = force_close.clone();
-                                    let toast = toast.clone();
                                     file_manager.save(
-                                        &parent,
+                                        &win,
                                         None,
-                                        &editor.text(),
+                                        &doc.editor.text(),
                                         move |outcome| match outcome {
-                                            Outcome::Ok(_) => {
-                                                force_close.set(true);
-                                                win.close();
+                                            Outcome::Ok(p) => {
+                                                doc.editor.set_base_dir(
+                                                    p.parent().map(Path::to_path_buf),
+                                                );
+                                                *doc.current_file.borrow_mut() = Some(p);
+                                                doc.is_modified.set(false);
+                                                finish_close(&page, true);
                                             }
                                             Outcome::Error(e) => {
                                                 toast(&format!("No se pudo guardar: {e}"));
+                                                doc.closing.set(false);
+                                                finish_close(&page, false);
                                             }
-                                            Outcome::Cancelled => {}
+                                            Outcome::Cancelled => {
+                                                doc.closing.set(false);
+                                                finish_close(&page, false);
+                                            }
                                         },
                                     );
                                 }
                             }
                         }
-                        _ => {}
+                        // Cancelar: se aborta el cierre de la pestaña.
+                        _ => {
+                            doc.closing.set(false);
+                            finish_close(&page, false);
+                        }
                     }
                 });
                 glib::Propagation::Stop
             });
         }
 
-        update_title();
-        update_status();
-        update_counts(&editor.text());
-        Self { window, load_file }
+        {
+            let toc_lines = toc_lines.clone();
+            let active_document = active_document.clone();
+            toc_list.connect_row_activated(move |_, row| {
+                let line = toc_lines.borrow().get(row.index() as usize).copied();
+                if let (Some(line), Some(doc)) = (line, active_document()) {
+                    doc.editor.scroll_to_line(line);
+                }
+            });
+        }
+        {
+            let refresh_recents = refresh_recents.clone();
+            search_entry
+                .connect_search_changed(move |entry| refresh_recents(entry.text().as_str()));
+        }
+        {
+            let active_document = active_document.clone();
+            let goto_spin = goto_spin.clone();
+            let goto_popover = goto_popover.clone();
+            goto_button.connect_clicked(move |_| {
+                if let Some(doc) = active_document() {
+                    doc.editor.go_to_line(goto_spin.value() as i32);
+                }
+                goto_popover.popdown();
+            });
+        }
+
+        // ---- autoguardado (D4/R1): UN temporizador de ventana que itera
+        // todos los documentos; el elapsed es por documento ----
+        {
+            let settings = settings.clone();
+            // Fuerte a propósito: el temporizador NO es un objeto de la
+            // ventana (vive en el main context) y junto con ScribeWindow es
+            // el ancla de la lista; termina cuando la ventana muere (alive).
+            let documents = documents.clone();
+            let refresh_tabs = refresh_tabs.clone();
+            let toast = toast.clone();
+            let alive = alive.clone();
+            glib::timeout_add_seconds_local(5, move || {
+                if !alive.get() {
+                    return glib::ControlFlow::Break;
+                }
+                if !settings.autosave() {
+                    return glib::ControlFlow::Continue;
+                }
+                // R1: clonar el Vec antes de iterar: puede cambiar durante
+                // el tick (guardar → toast → señales → alta/baja de
+                // documentos).
+                let docs = documents.borrow().clone();
+                for doc in docs {
+                    doc.autosave_elapsed.set(doc.autosave_elapsed.get() + 5);
+                    if doc.autosave_elapsed.get() < settings.autosave_interval() {
+                        continue;
+                    }
+                    doc.autosave_elapsed.set(0);
+                    if !doc.is_modified.get() {
+                        continue;
+                    }
+                    let Some(path) = doc.current_file.borrow().clone() else {
+                        continue;
+                    };
+                    match std::fs::write(&path, doc.editor.text()) {
+                        Ok(()) => {
+                            doc.is_modified.set(false);
+                            // También quita el «•»/needs_attention de las
+                            // pestañas no activas (D4).
+                            refresh_tabs();
+                            doc.autosave_failed.set(false);
+                        }
+                        // Sin este aviso el usuario confía en una copia
+                        // automática que no existe.
+                        Err(e) => {
+                            if !doc.autosave_failed.replace(true) {
+                                toast(&format!("No se pudo autoguardar: {e}"));
+                            }
+                        }
+                    }
+                }
+                glib::ControlFlow::Continue
+            });
+        }
+
+        // ---- cierre de la ventana con N documentos modificados ----
+        {
+            let settings = settings.clone();
+            let documents = Rc::downgrade(&documents);
+            let force_close = force_close.clone();
+            let alive = alive.clone();
+            let file_manager = file_manager.clone();
+            let toast = toast.clone();
+            window.connect_close_request(move |win| {
+                if force_close.get() {
+                    alive.set(false);
+                    return glib::Propagation::Proceed;
+                }
+                if closing_window.get() {
+                    // Ya hay una cadena de dialogos en curso.
+                    return glib::Propagation::Stop;
+                }
+                let Some(docs) = documents.upgrade() else {
+                    alive.set(false);
+                    return glib::Propagation::Proceed;
+                };
+                // En orden de pestaña (ask_save_step saca por el final).
+                let modified: Vec<Rc<Document>> = docs
+                    .borrow()
+                    .iter()
+                    .filter(|d| d.is_modified.get())
+                    .cloned()
+                    .rev()
+                    .collect();
+                if modified.is_empty() {
+                    persist_geometry(win, &settings);
+                    alive.set(false);
+                    return glib::Propagation::Proceed;
+                }
+
+                // Diálogos secuenciales por documento (como GNOME Text
+                // Editor): Cancelar aborta todo; al resolverlos todos se
+                // persiste la geometría y se cierra de verdad.
+                let on_done = {
+                    let settings = settings.clone();
+                    let force_close = force_close.clone();
+                    let alive = alive.clone();
+                    Rc::new(move |win: &adw::ApplicationWindow| {
+                        persist_geometry(win, &settings);
+                        alive.set(false);
+                        force_close.set(true);
+                        win.close();
+                    })
+                };
+                closing_window.set(true);
+                let on_abort = {
+                    let closing_window = closing_window.clone();
+                    Rc::new(move || closing_window.set(false))
+                };
+                ask_save_step(
+                    win.clone(),
+                    Rc::new(RefCell::new(modified)),
+                    file_manager.clone(),
+                    toast.clone(),
+                    on_done,
+                    on_abort,
+                );
+                glib::Propagation::Stop
+            });
+        }
+
+        // Documento inicial en blanco, como el editor mono-documento de
+        // antes y como gnome-text-editor al arrancar sin ficheros.
+        create_document(String::new(), None);
+
+        Self {
+            window,
+            load_file,
+            documents,
+            tab_view,
+        }
     }
 
     pub fn open_path(&self, path: &Path) {
@@ -1143,5 +1767,17 @@ impl ScribeWindow {
 
     pub fn present(&self) {
         self.window.present();
+    }
+
+    /// Número de páginas del TabView (smoke tests; el binario no lo usa).
+    #[allow(dead_code)]
+    pub fn page_count(&self) -> i32 {
+        self.tab_view.n_pages()
+    }
+
+    /// Número de documentos vivos en la lista interna (smoke tests).
+    #[allow(dead_code)]
+    pub fn document_count(&self) -> usize {
+        self.documents.borrow().len()
     }
 }

--- a/tests/render_shot.rs
+++ b/tests/render_shot.rs
@@ -1,9 +1,10 @@
-//! Captura visual del editor: renderiza un documento de muestra a PNG para
+//! Captura visual del editor: renderiza un documento a PNGs paginados para
 //! verificar la vista enriquecida (tablas, cajas de código, filetes de
 //! título, citas, listas, imágenes) sin abrir ventanas interactivas.
 //!
 //! Ejecutar: xvfb-run -a cargo test --test render_shot -- --ignored --nocapture
-//! Salida:   /mnt/agents/work/shots/*.png
+//! Entrada:  MD_PATH (por defecto, documento de muestra integrado)
+//! Salida:   /mnt/agents/work/shots/pagina-NN.png
 
 // Los módulos de la app se incluyen vía #[path] y el harness solo ejercita
 // parte de su API: el resto aparece como código muerto aunque la app sí lo
@@ -26,30 +27,10 @@ use std::time::{Duration, Instant};
 const DOC: &str = "\
 # Título principal
 
-## Sección con *énfasis* y `código`
-
-Texto normal con **negrita** y un [enlace](https://ejemplo.com).
-
 | Command    | Description                      | Precio |
 | ---------- | -------------------------------- | -----: |
 | git status | List all **new** or modified     |    $12 |
 | git diff   | Show file `differences`          |  $1600 |
-
-> Una cita con **marcado**
-> y dos líneas.
-
-- [x] Tarea hecha
-- [ ] Tarea pendiente
-- Elemento normal
-
----
-
-```python
-def f():
-    return 1  # comentario
-```
-
-![gatito](test.png)
 ";
 
 /// PNG de 64x48 generado con un codificador real (bicolor rojo/azul), para
@@ -72,9 +53,9 @@ fn pump(ctx: &gtk4::glib::MainContext, ms: u64) {
     }
 }
 
-/// Renderiza el contenido de un widget a un PNG usando el renderer de la
-/// ventana ya realizada.
-fn shot(win: &gtk4::Window, path: &str) {
+/// Renderiza el contenido visible de la ventana a un PNG usando el renderer
+/// de la superficie ya realizada.
+fn shot(win: &gtk4::Window, path: &std::path::Path) {
     let w = win.width() as f64;
     let h = win.height() as f64;
     let paintable = gtk4::WidgetPaintable::new(Some(win));
@@ -102,6 +83,12 @@ fn captura_vista_enriquecida() {
     std::fs::create_dir_all(&out).expect("crear dir de salida");
     std::fs::write(out.join("test.png"), TEST_PNG).expect("escribir imagen de prueba");
 
+    // Documento: el indicado por MD_PATH o la muestra integrada.
+    let doc = std::env::var("MD_PATH")
+        .ok()
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .unwrap_or_else(|| DOC.to_string());
+
     let editor = Editor::new();
     editor.set_base_dir(Some(out.to_path_buf()));
     let win = gtk4::Window::builder()
@@ -112,9 +99,21 @@ fn captura_vista_enriquecida() {
     win.present();
 
     let ctx = gtk4::glib::MainContext::default();
-    editor.set_text(DOC);
-    pump(&ctx, 600); // drena el debounce de decoración y el layout
+    editor.set_text(&doc);
+    pump(&ctx, 800); // drena el debounce de decoración y el layout
 
-    shot(&win, &out.join("vista.png").display().to_string());
-    eprintln!("captura escrita en {}", out.join("vista.png").display());
+    let total = editor.line_count().max(1);
+    // Filas de texto por página (~1000 px de ventana): paginar con solape de
+    // una línea para no cortar cajas ni tablas a la mitad sin contexto.
+    let per_page = 38usize;
+    let mut first = 0usize;
+    let mut page = 0usize;
+    while first < total as usize {
+        editor.scroll_to_line(first as i32);
+        pump(&ctx, 350);
+        shot(&win, &out.join(format!("pagina-{page:02}.png")));
+        page += 1;
+        first += per_page;
+    }
+    eprintln!("{page} paginas escritas en {}", out.display());
 }

--- a/tests/tabs_smoke.rs
+++ b/tests/tabs_smoke.rs
@@ -1,0 +1,229 @@
+//! Smoke test headless del modelo de pestañas (AdwTabView): crea una ventana
+//! bajo xvfb y ejercita el ciclo de vida completo —apertura vía acciones,
+//! deduplicación por ruta canónica, cierre sin cambios, refresco del título
+//! al cambiar de pestaña, punto «• » al modificar, guardado, y la regla D5
+//! (al cerrar la última pestaña queda una en blanco).
+//!
+//! Ejecutar: xvfb-run -a cargo test --test tabs_smoke -- --ignored --nocapture
+
+// Los módulos de la app se incluyen vía #[path] y el harness solo ejercita
+// parte de su API: el resto aparece como código muerto aunque la app sí lo
+// use (mismo criterio que tests/crash_stress.rs).
+#![allow(dead_code)]
+
+#[path = "../src/editor.rs"]
+mod editor;
+#[path = "../src/file_manager.rs"]
+mod file_manager;
+#[path = "../src/markdown_render.rs"]
+mod markdown_render;
+#[path = "../src/markdown_view.rs"]
+mod markdown_view;
+#[path = "../src/preferences.rs"]
+mod preferences;
+#[path = "../src/preview.rs"]
+mod preview;
+#[path = "../src/settings.rs"]
+mod settings;
+#[path = "../src/templates.rs"]
+mod templates;
+#[path = "../src/window.rs"]
+mod window;
+
+use gtk4::prelude::*;
+use settings::AppSettings;
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::time::{Duration, Instant};
+use window::ScribeWindow;
+
+/// Bombea el main context durante `ms` milisegundos: drena los debounces de
+/// decoración y los refrescos diferidos de título/TOC/preview.
+fn pump(ctx: &gtk4::glib::MainContext, ms: u64) {
+    let t = Instant::now();
+    while t.elapsed() < Duration::from_millis(ms) {
+        while ctx.iteration(false) {}
+        std::thread::sleep(Duration::from_millis(4));
+    }
+}
+
+/// Renderiza la ventana a PNG (misma técnica que tests/render_shot.rs) para
+/// tener prueba visual de la barra de pestañas.
+fn shot(win: &gtk4::Window, path: &std::path::Path) {
+    let w = win.width() as f64;
+    let h = win.height() as f64;
+    let paintable = gtk4::WidgetPaintable::new(Some(win));
+    let snapshot = gtk4::Snapshot::new();
+    paintable.snapshot(&snapshot, w, h);
+    let node = snapshot.to_node().expect("snapshot sin nodo raíz");
+    let renderer = win
+        .native()
+        .expect("sin native")
+        .renderer()
+        .expect("sin renderer");
+    let texture = renderer.render_texture(&node, None);
+    texture.save_to_png(path).expect("guardar png");
+}
+
+/// Desambigua `activate_action`: en una ventana conviven ActionGroupExt y
+/// WidgetExt; queremos el de Widget (acciones `win.*`).
+fn act(
+    win: &libadwaita::ApplicationWindow,
+    name: &str,
+    param: Option<&gtk4::glib::Variant>,
+) -> Result<(), gtk4::glib::BoolError> {
+    gtk4::prelude::WidgetExt::activate_action(win, name, param)
+}
+#[test]
+#[ignore = "requiere display: xvfb-run -a cargo test --test tabs_smoke -- --ignored --nocapture"]
+fn ciclo_de_vida_de_pestanas() {
+    gtk4::init().expect("GTK necesita un display; ejecuta bajo xvfb-run");
+    libadwaita::init().expect("libadwaita init");
+
+    // Sin GSETTINGS_SCHEMA_DIR el esquema no se encuentra y AppSettings
+    // trabaja con los valores por defecto: el test no toca el dconf real.
+    let app = libadwaita::Application::builder()
+        .application_id("app.scribe.Scribe.TabsSmoke")
+        .build();
+    app.register(gtk4::gio::Cancellable::NONE)
+        .expect("registrar la app de test");
+
+    let settings = Rc::new(AppSettings::new());
+    let win = ScribeWindow::new(&app, &settings);
+    win.present();
+
+    let ctx = gtk4::glib::MainContext::default();
+    pump(&ctx, 300);
+
+    // La ventana arranca con una pestaña en blanco.
+    assert_eq!(win.page_count(), 1, "la ventana arranca con una en blanco");
+    assert_eq!(win.document_count(), 1);
+
+    // Tres documentos de muestra en el directorio temporal.
+    let dir = std::env::temp_dir().join("scribe-tabs-smoke");
+    std::fs::create_dir_all(&dir).expect("crear dir temporal");
+    let paths: Vec<PathBuf> = ["alfa.md", "beta.md", "gamma.md"]
+        .iter()
+        .map(|n| dir.join(n))
+        .collect();
+    for (i, p) in paths.iter().enumerate() {
+        std::fs::write(p, format!("# Doc {i}\n\ncontenido de prueba {i}\n"))
+            .expect("escribir doc de prueba");
+    }
+
+    // Abrir los tres vía la acción win.open-recent (la misma vía que el menú
+    // de recientes; no necesita diálogo). La primera apertura reutiliza la
+    // pestaña virgen, así que quedan exactamente 3.
+    for p in &paths {
+        let target = p.to_string_lossy().to_string().to_variant();
+        act(&win.window, "win.open-recent", Some(&target)).expect("activar win.open-recent");
+        pump(&ctx, 150);
+    }
+    assert_eq!(win.page_count(), 3, "tres documentos, tres pestañas");
+    assert_eq!(win.document_count(), 3);
+
+    // Prueba visual: la barra de pestañas con los tres documentos.
+    let shots_dir = std::path::Path::new("/mnt/agents/work/shots");
+    if shots_dir.is_dir() {
+        shot(
+            &win.window.clone().upcast(),
+            &shots_dir.join("pestanas.png"),
+        );
+    }
+
+    // D6/R5: reabrir un path ya abierto no crea pestaña; selecciona la
+    // existente (el título de la ventana pasa a ser el suyo).
+    win.open_path(&paths[0]);
+    pump(&ctx, 150);
+    assert_eq!(win.page_count(), 3, "dedupe por ruta canónica");
+    assert_eq!(win.document_count(), 3);
+    let title = win
+        .window
+        .title()
+        .map(|t| t.to_string())
+        .unwrap_or_default();
+    assert!(title.contains("alfa.md"), "título inesperado: {title}");
+
+    // Cerrar la pestaña activa sin cambios: no hay diálogo.
+    act(&win.window, "win.close-tab", None).expect("activar win.close-tab");
+    pump(&ctx, 150);
+    assert_eq!(win.page_count(), 2, "cerrar sin cambios cierra");
+    assert_eq!(win.document_count(), 2);
+    // Tras cerrar alfa queda seleccionada su vecina (beta).
+    let title = win
+        .window
+        .title()
+        .map(|t| t.to_string())
+        .unwrap_or_default();
+    assert!(title.contains("beta.md"), "título inesperado: {title}");
+
+    // Modificar la activa marca el título con «• »…
+    act(&win.window, "win.bold", None).expect("activar win.bold");
+    pump(&ctx, 150);
+    let title = win
+        .window
+        .title()
+        .map(|t| t.to_string())
+        .unwrap_or_default();
+    assert!(
+        title.starts_with('•'),
+        "el título debe marcarse al modificar: {title}"
+    );
+    // …y win.save (tiene fichero, sin diálogo) lo quita.
+    act(&win.window, "win.save", None).expect("activar win.save");
+    pump(&ctx, 150);
+    let title = win
+        .window
+        .title()
+        .map(|t| t.to_string())
+        .unwrap_or_default();
+    assert!(
+        !title.starts_with('•'),
+        "el título debe limpiarse al guardar: {title}"
+    );
+
+    // Cambiar de pestaña refresca el título de la ventana.
+    act(&win.window, "win.tab-next", None).expect("activar win.tab-next");
+    pump(&ctx, 150);
+    let title = win
+        .window
+        .title()
+        .map(|t| t.to_string())
+        .unwrap_or_default();
+    assert!(title.contains("gamma.md"), "título inesperado: {title}");
+    act(&win.window, "win.tab-prev", None).expect("activar win.tab-prev");
+    pump(&ctx, 150);
+    let title = win
+        .window
+        .title()
+        .map(|t| t.to_string())
+        .unwrap_or_default();
+    assert!(title.contains("beta.md"), "título inesperado: {title}");
+
+    // D5: al cerrar todas queda una pestaña en blanco; la ventana no se
+    // cierra.
+    act(&win.window, "win.close-tab", None).expect("cerrar beta");
+    pump(&ctx, 150);
+    act(&win.window, "win.close-tab", None).expect("cerrar gamma");
+    pump(&ctx, 150);
+    assert_eq!(win.page_count(), 1, "D5: queda una pestaña en blanco");
+    assert_eq!(win.document_count(), 1);
+    let title = win
+        .window
+        .title()
+        .map(|t| t.to_string())
+        .unwrap_or_default();
+    assert!(
+        title.contains("Sin título"),
+        "la pestaña nueva es un borrador: {title}"
+    );
+
+    // Los documentos cerrados sin cambios no dejaron diálogos colgados.
+    assert_eq!(win.page_count(), win.document_count() as i32);
+
+    // Cierre de ventana sin modificados: prospera sin diálogos.
+    win.window.close();
+    pump(&ctx, 100);
+
+    std::fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
## Tabs

Real multi-document model with `AdwTabView` + `AdwTabBar` (gnome-text-editor style). The previous "tabs" were the recents list reloading the same buffer (and clobbering unsaved changes). Now each document has its own editor, undo, save state and tab:

- `Ctrl+N` new tab · `Ctrl+O` / recents / `scribe file.md` open tabs · `Ctrl+W` close · `Ctrl+Tab` / `Ctrl+Shift+Tab` / `Ctrl+PgUp` / `Ctrl+PgDn` navigate
- Opening an already-open file focuses its tab (dedupe by canonical path)
- Close a dirty tab: Save/Discard/Cancel dialog; close the window with several dirty docs: sequential dialogs; cancel aborts everything
- Modified dot on the tab + attention badge when in background; per-document autosave clears the indicators of background tabs too; shared preview re-renders on tab switch
- `CssProvider` for the font is now installed once per app instead of once per editor; window geometry only persists if the close succeeds

## Block box fix

The background box was extended off-screen to hide its corners; with a very negative origin GSK paints nothing, so the box disappeared in the middle of long blocks (reproduced on a 120-line fence). The rectangle is now clipped to the visible area and rounded corners only draw on the real block edges; the quote bar uses the same rule.

## Checks

- 52/52 tests, clippy `-D warnings`, rustfmt clean
- `tabs_smoke` (full tab lifecycle headless) and `render_shot` pass under xvfb
- `crash_stress` (60 opens, WYSIWYG path) passes without SIGABRT; the GTK canary still aborts as expected on the vulnerable GTK 4.22.4

Closes #9